### PR TITLE
[Clean] warnings, try catch, unused code

### DIFF
--- a/src/LCClogDemons/itkLCCDeformableRegistrationFilter.txx
+++ b/src/LCClogDemons/itkLCCDeformableRegistrationFilter.txx
@@ -72,13 +72,8 @@ void
 LCCDeformableRegistrationFilter<TFixedImage, TMovingImage, TField>
 ::SetInitialVelocityField( VelocityFieldType * ptr )
 {
-#if (ITK_VERSION_MAJOR < 4)
-  this->SetNthInput( 0, ptr );
-#else
-  this->SetNthInput( 0, ptr );
-#endif
+    this->SetNthInput( 0, ptr );
 }
-
 
 // Set the fixed image.
 template <class TFixedImage, class TMovingImage, class TField>
@@ -87,13 +82,8 @@ LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 ::SetFixedImage(
   const FixedImageType * ptr )
 {
-#if (ITK_VERSION_MAJOR < 4)
-  this->ProcessObject::SetNthInput( 1, const_cast< FixedImageType * >( ptr ) );
-#else
-  this->ProcessObject::SetNthInput( 1, const_cast<FixedImageType *>( ptr ) );
-#endif
+    this->ProcessObject::SetNthInput( 1, const_cast< FixedImageType * >( ptr ) );
 }
-
 
 // Get the fixed image.
 template <class TFixedImage, class TMovingImage, class TField>
@@ -102,14 +92,8 @@ const typename LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 ::GetFixedImage() const
 {
-  return dynamic_cast< const FixedImageType * >
-#if (ITK_VERSION_MAJOR < 4)
-    ( this->ProcessObject::GetInput( 1 ) );
-#else
-         ( this->ProcessObject::GetInput( 1 ) );
-#endif
+    return dynamic_cast< const FixedImageType * >(this->ProcessObject::GetInput(1));
 }
-
 
 // Set the moving image.
 template <class TFixedImage, class TMovingImage, class TField>
@@ -118,13 +102,8 @@ LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 ::SetMovingImage(
   const MovingImageType * ptr )
 {
-#if (ITK_VERSION_MAJOR < 4)
-  this->ProcessObject::SetNthInput( 2, const_cast< MovingImageType * >( ptr ) );
-#else
-  this->ProcessObject::SetNthInput( 2, const_cast<MovingImageType *>( ptr ) );
-#endif
+    this->ProcessObject::SetNthInput( 2, const_cast<MovingImageType *>( ptr ) );
 }
-
 
 // Get the moving image.
 template <class TFixedImage, class TMovingImage, class TField>
@@ -133,12 +112,7 @@ const typename LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 ::GetMovingImage() const
 {
-  return dynamic_cast< const MovingImageType * >
-#if (ITK_VERSION_MAJOR < 4)
-    ( this->ProcessObject::GetInput( 2 ) );
-#else
-         ( this->ProcessObject::GetInput( 2 ) );
-#endif
+  return dynamic_cast< const MovingImageType * >(this->ProcessObject::GetInput(2));
 }
 
 // Set the flag for the mask image.
@@ -165,7 +139,8 @@ void
 LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 ::SetMaskImage(
   const MovingImageType * ptr )
-{ m_MaskImage = MovingImageType::New(); 
+{ 
+  m_MaskImage = MovingImageType::New(); 
   m_MaskImage =ptr;
 }
 
@@ -304,8 +279,10 @@ LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 ::SetStandardDeviationsWorldUnit( double value )
 {
     double tmp[ImageDimension];
-    for( int i=0; i<ImageDimension; i++ )
+    for( unsigned int i=0; i<ImageDimension; i++ )
+    {
         tmp[i] = value;
+    }
     SetStandardDeviationsWorldUnit( tmp );
 }
 
@@ -348,8 +325,10 @@ LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 ::SetStandardDeviationsVoxelUnit( double value )
 {
     double tmp[ImageDimension];
-    for( int i=0; i<ImageDimension; i++ )
+    for( unsigned int i=0; i<ImageDimension; i++ )
+    {
         tmp[i] = value;
+    }
     SetStandardDeviationsVoxelUnit( tmp );
 }
 
@@ -422,8 +401,10 @@ LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 ::SetUpdateFieldStandardDeviationsWorldUnit( double value )
 {
     double tmp[ImageDimension];
-    for( int i=0; i<ImageDimension; i++ )
+    for( unsigned int i=0; i<ImageDimension; i++ )
+    {
         tmp[i] = value;
+    }
     SetUpdateFieldStandardDeviationsWorldUnit( tmp );
 }
 
@@ -466,8 +447,10 @@ LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 ::SetUpdateFieldStandardDeviationsVoxelUnit( double value )
 {
     double tmp[ImageDimension];
-    for( int i=0; i<ImageDimension; i++ )
+    for( unsigned int i=0; i<ImageDimension; i++ )
+    {
         tmp[i] = value;
+    }
     SetUpdateFieldStandardDeviationsVoxelUnit( tmp );
 }
 
@@ -533,16 +516,16 @@ LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 
 }
 
-
-
 template <class TFixedImage, class TMovingImage, class TField>
 void
 LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 ::SetSimilarityCriteriaStandardDeviationsWorldUnit( double value )
 {
     double tmp[ImageDimension];
-    for( int i=0; i<ImageDimension; i++ )
+    for( unsigned int i=0; i<ImageDimension; i++ )
+    {
         tmp[i] = value;
+    }
     SetSimilarityCriteriaStandardDeviationsWorldUnit( tmp );
 }
 
@@ -577,16 +560,16 @@ LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
     }
 }
 
-
-
 template <class TFixedImage, class TMovingImage, class TField>
 void
 LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 ::SetSimilarityCriteriaStandardDeviationsVoxelUnit( double value )
 {
     double tmp[ImageDimension];
-    for( int i=0; i<ImageDimension; i++ )
+    for( unsigned int i=0; i<ImageDimension; i++ )
+    {
         tmp[i] = value;
+    }
     SetSimilarityCriteriaStandardDeviationsVoxelUnit( tmp );
 }
 
@@ -627,26 +610,22 @@ const double *
 LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 ::GetSimilarityCriteriaStandardDeviations( ) const
 {   
-        static double stDev[ImageDimension] ;
-   for( unsigned int j = 0; j < ImageDimension; j++ )
-      {
-
-          // Computation of the standard deviation (voxel unit) of the Gaussian kernel for the similarity criteria
+    static double stDev[ImageDimension] ;
+    for( unsigned int j = 0; j < ImageDimension; j++ )
+    {
+        // Computation of the standard deviation (voxel unit) of the Gaussian kernel for the similarity criteria
         if ( m_StandardDeviationWorldUnit )
         {   
-	    double s = this->GetFixedImage()->GetSpacing()[j];
+            double s = this->GetFixedImage()->GetSpacing()[j];
             stDev[j] =  this->m_SimilarityCriteriaStandardDeviations[j] / (s);
-           // stDev[j] = s*s*this->m_SimilarityCriteriaStandardDeviations[j];
-
         }
         else
+        {
             stDev[j] =  this->m_SimilarityCriteriaStandardDeviations[j] ;
+        }
      }
-
-      //std::cout<<"Std Dev: "<<stDev[1]<<std::endl;
-
-      return(static_cast<const double*> (stDev)); 
-  }
+    return(static_cast<const double*> (stDev)); 
+}
 
 template <class TFixedImage, class TMovingImage, class TField>
 void
@@ -717,7 +696,6 @@ void
 LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 ::InitializeIteration()
 {
-  //std::cout<<"LCCDeformableRegistrationFilter::InitializeIteration"<<std::endl;
   MovingImageConstPointer movingPtr = this->GetMovingImage();
   FixedImageConstPointer fixedPtr = this->GetFixedImage();
 
@@ -753,11 +731,7 @@ void
 LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 ::CopyInputToOutput()
 {
-#if (ITK_VERSION_MAJOR < 4)
   typename Superclass::InputImageType::ConstPointer  inputPtr  = this->GetInput(0);
-#else
-  typename Superclass::InputImageType::ConstPointer  inputPtr  = this->GetInput(0);
-#endif
 
   if( inputPtr )
     {
@@ -789,14 +763,9 @@ void
 LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 ::GenerateOutputInformation()
 {
-  //std::cout<<"LCCDeformableRegistrationFilter::GenerateOutputInformation"<<std::endl;
   typename DataObject::Pointer output;
 
-#if (ITK_VERSION_MAJOR < 4)
   if( this->GetInput(0) )
-#else
-  if( this->GetInput(0) )
-#endif
     {
     // Initial velocity field is set.
     // Copy information from initial field.
@@ -805,7 +774,7 @@ LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
     }
   else if( this->GetFixedImage() )
     {
-    // Initial deforamtion field is not set. 
+    // Initial deformation field is not set. 
     // Copy information from the fixed image.
     for (unsigned int idx = 0; idx < 
            this->GetNumberOfOutputs(); ++idx )
@@ -827,41 +796,32 @@ void
 LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 ::GenerateInputRequestedRegion()
 {
-  //std::cout<<"LCCDeformableRegistrationFilter::GenerateInputRequestedRegion"<<std::endl;
   // call the superclass's implementation
   Superclass::GenerateInputRequestedRegion();
 
   // request the largest possible region for the moving image
-  MovingImagePointer movingPtr = 
-    const_cast< MovingImageType * >( this->GetMovingImage() );
+  MovingImagePointer movingPtr = const_cast< MovingImageType * >(this->GetMovingImage());
   if( movingPtr )
-    {
+  {
     movingPtr->SetRequestedRegionToLargestPossibleRegion();
-    }
+  }
   
   // just propagate up the output requested region for
   // the fixed image and initial velocity field.
-#if (ITK_VERSION_MAJOR < 4)
-  VelocityFieldPointer inputPtr = 
-    const_cast< VelocityFieldType * >( this->GetInput(0) );
-#else
-  VelocityFieldPointer inputPtr =
-    const_cast<VelocityFieldType *>( this->GetInput(0) );
-#endif
-
+  VelocityFieldPointer inputPtr = const_cast< VelocityFieldType * >( this->GetInput(0) );
   VelocityFieldPointer outputPtr = this->GetOutput();
-  FixedImagePointer fixedPtr = 
-    const_cast< FixedImageType *>( this->GetFixedImage() );
+
+  FixedImagePointer fixedPtr = const_cast< FixedImageType *>( this->GetFixedImage() );
 
   if( inputPtr )
-    {
+  {
     inputPtr->SetRequestedRegion( outputPtr->GetRequestedRegion() );
-    }
+  }
 
   if( fixedPtr )
-    {
+  {
     fixedPtr->SetRequestedRegion( outputPtr->GetRequestedRegion() );
-    }
+  }
 }
 
 
@@ -882,7 +842,6 @@ void
 LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 ::Initialize()
 {
-  //std::cout<<"LCCDeformableRegistrationFilter::Initialize"<<std::endl;
   this->Superclass::Initialize();
   m_StopRegistrationFlag = false;
 }
@@ -894,36 +853,14 @@ void
 LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 ::SmoothVelocityField()
 { 
-
-  if (m_RegularizationType == 1)
-    {
-
-      /*
-      float param[2];
-       param[0]=m_HarmonicWeight;
-       param[1]=m_BendingWeight;
-
-       typedef typename itk::VectorRegularizationFilter<VelocityFieldType> RegularizerType;
-       //std::cout<<param[0]<<" "<<param[1]<<std::endl;
-
-       typename RegularizerType::Pointer Regularizer=RegularizerType::New();
-       Regularizer->SetInput(this->GetOutput());
-       Regularizer->SetFactor(param);
-
-       Regularizer->Update();
-
-       this->GraftOutput(Regularizer->GetOutput());
-       */
-      }
-  else if (m_RegularizationType == 0)
-    {
+  if (m_RegularizationType == 0)
+  {
      if (this->GetSmoothVelocityField())
-        {
+     {
          // The output buffer will be overwritten with new data.
          this->SmoothGivenField(this->GetOutput(), this->m_StandardDeviations);
-        }
-    }
- 
+     }
+  }
 }
 
 // Smooth update field using a separable Gaussian kernel
@@ -932,21 +869,11 @@ void
 LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 ::SmoothUpdateField()
 {
-
- if (m_RegularizationType == 0)
-  {
-    /*double variance[ImageDimension];
-    for( unsigned int j = 0; j < ImageDimension; j++ )
-      {
-       double s = this->GetUpdateBuffer()->GetSpacing()[j];
-       variance[j] = this->m_UpdateFieldStandardDeviations[j]/(s) ;
-      }*/
-    this->SmoothGivenField(this->GetUpdateBuffer(), this->m_UpdateFieldStandardDeviations);//this->m_UpdateFieldStandardDeviations);
-   }
- else {}
-
+    if (m_RegularizationType == 0)
+    {
+        this->SmoothGivenField(this->GetUpdateBuffer(), this->m_UpdateFieldStandardDeviations);
+    }
 }
-
 
 // Smooth velocity using a separable Gaussian kernel
 template <class TFixedImage, class TMovingImage, class TField>
@@ -954,7 +881,6 @@ void
 LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 ::SmoothGivenField(VelocityFieldType * field, const double StandardDeviations[ImageDimension])
 {
-
     // copy field to TempField
     m_TempField->SetOrigin( field->GetOrigin() );
     m_TempField->SetSpacing( field->GetSpacing() );
@@ -997,7 +923,6 @@ LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
         else
             variance = StandardDeviations[j] * StandardDeviations[j];
 
-        //std::cout << "Standard deviation : " << StandardDeviations[j] << std::endl;
 
         // Set other parameters
         oper->SetVariance( variance );
@@ -1008,7 +933,16 @@ LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
         // todo: make sure we only smooth within the buffered region
         smoother->SetOperator( *oper );
         smoother->SetInput( field );
-        smoother->Update();
+
+        try
+        {
+            smoother->Update();
+        }
+        catch (itk::ExceptionObject & err)
+        {
+            std::cerr << "ExceptionObject caught !" << std::endl;
+            std::cerr << err << std::endl;
+        }
 
         if ( j < ImageDimension - 1 )
         {
@@ -1042,11 +976,19 @@ typename LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 ::GetDeformationField()
 { 
-
-  //std::cout<<"LCCDeformableRegistration::GetDeformationField"<<std::endl;
   m_Exponentiator->SetInput( this->GetVelocityField() );
   m_Exponentiator->GetOutput()->SetRequestedRegion( this->GetVelocityField()->GetRequestedRegion() );
-  m_Exponentiator->Update();
+
+  try
+  {
+      m_Exponentiator->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+      std::cerr << "ExceptionObject caught !" << std::endl;
+      std::cerr << err << std::endl;
+  }  
+
   return m_Exponentiator->GetOutput();
 }
 
@@ -1057,10 +999,19 @@ typename LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 LCCDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 ::GetInverseDeformationField()
 {
-  //std::cout<<"LCCDeformableRegistration::GetInverseDeformationField"<<std::endl;
   m_InverseExponentiator->SetInput( this->GetVelocityField() );
   m_InverseExponentiator->GetOutput()->SetRequestedRegion( this->GetVelocityField()->GetRequestedRegion() );
-  m_InverseExponentiator->Update();
+
+  try
+  {
+      m_InverseExponentiator->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+      std::cerr << "ExceptionObject caught !" << std::endl;
+      std::cerr << err << std::endl;
+  }  
+
   return m_InverseExponentiator->GetOutput();
 }
 

--- a/src/LCClogDemons/itkLCClogDemonsRegistrationFilter.txx
+++ b/src/LCClogDemons/itkLCClogDemonsRegistrationFilter.txx
@@ -70,7 +70,6 @@ void
 LCClogDemonsRegistrationFilter<TFixedImage,TMovingImage,TField>
 ::InitializeIteration()
 {
-    //std::cout<<"LCClogDemonsRegistrationFilter::InitializeIteration"<<std::endl;
     // update variables in the equation object
     DemonsRegistrationFunctionType *f = this->DownCastDifferenceFunctionType();
 
@@ -199,14 +198,6 @@ LCClogDemonsRegistrationFilter<TFixedImage,TMovingImage,TField>
 ::ApplyUpdate(const TimeStepType& dt)
 #endif
 {
-    //std::cout<<"LCClogDemonsRegistrationFilter::ApplyUpdate"<<std::endl;
-    // If we smooth the update buffer before applying it, then the are
-    // approximating a viscuous problem as opposed to an elastic problem
-    /*if ( this->GetSmoothUpdateField() )
-    {
-        this->SmoothUpdateField();
-    }
-*/
     // Use time step if necessary. In many cases
     // the time step is one so this will be skipped
     if ( fabs(dt - 1.0)>1.0e-4 )
@@ -216,7 +207,15 @@ LCClogDemonsRegistrationFilter<TFixedImage,TMovingImage,TField>
         m_Multiplier->SetInput( this->GetUpdateBuffer() );
         m_Multiplier->GraftOutput( this->GetUpdateBuffer() );
         // in place update
-        m_Multiplier->Update();
+        try
+        {
+           m_Multiplier->Update();
+        }
+        catch (itk::ExceptionObject & err)
+        {
+            std::cerr << "ExceptionObject caught !" << std::endl;
+            std::cerr << err << std::endl;
+        }
         // graft output back to this->GetUpdateBuffer()
         this->GetUpdateBuffer()->Graft( m_Multiplier->GetOutput() );
     }
@@ -236,21 +235,19 @@ LCClogDemonsRegistrationFilter<TFixedImage,TMovingImage,TField>
     }
     m_BCHFilter->GetOutput()->SetRequestedRegion( this->GetOutput()->GetRequestedRegion() );
 
-    // Triggers in place update
-    m_BCHFilter->Update();
+    try
+    {
+        // Triggers in place update
+        m_BCHFilter->Update();
+    }
+    catch (itk::ExceptionObject & err)
+    {
+        std::cerr << "ExceptionObject caught !" << std::endl;
+        std::cerr << err << std::endl;
+    }
 
     // Region passing stuff
     this->GraftOutput( m_BCHFilter->GetOutput() );
-
-
-/**Smooth the velocity field
-  *WARNING!!! To implement with the Local Criteria!!!
-  
-    if( this->GetSmoothVelocityField() )
-    {
-        this->SmoothVelocityField(this->GetFixedImage());
-    }
-**/
 }
 
 

--- a/src/LCClogDemons/itkLocalCriteriaOptimizer.h
+++ b/src/LCClogDemons/itkLocalCriteriaOptimizer.h
@@ -104,7 +104,13 @@ class ITK_EXPORT LocalCriteriaOptimizer :
         typedef WarpImageFilter<MovingImageType,MovingImageType,VectorImageType> WarperType;
 
 
-		void SetSigma(const double Sigma[FixedImageDimension] ){for (int i=0;i<FixedImageDimension;++i) m_Sigma[i]=Sigma[i];};
+		void SetSigma(const double Sigma[FixedImageDimension] )
+		{
+			for (unsigned int i=0;i<FixedImageDimension;++i)
+			{
+				m_Sigma[i]=Sigma[i];
+			}
+		};
 
 
 		void SetMaskImage(FixedImageConstPointer Mask )

--- a/src/LCClogDemons/itkLocalCriteriaOptimizer.txx
+++ b/src/LCClogDemons/itkLocalCriteriaOptimizer.txx
@@ -116,13 +116,14 @@ itk::SmartPointer<TImageType1> DivisionV(itk::SmartPointer<TImageType1> Image1, 
   
   typename TImageType1::PixelType vector;
   for( It.GoToBegin(); !It.IsAtEnd(); ++It )
-    {
+  {
       IndexV=It.GetIndex();	
       for (int i=0;i<dim;++i)
+      {
         vector[i]=Image1->GetPixel(IndexV)[i]/Image2->GetPixel(IndexV);
-        It.Set(vector);
-          
-    }
+      }
+      It.Set(vector);    
+  }
 
   return(output);
 }
@@ -194,8 +195,16 @@ typedef itk::ImageDuplicator< TImageType > DuplicatorType;
  typename DuplicatorType::Pointer duplicator = DuplicatorType::New();
  
  duplicator->SetInputImage(InputImage);
- duplicator->Update();
 
+  try
+  {
+      duplicator->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+      std::cerr << "ExceptionObject caught !" << std::endl;
+      std::cerr << err << std::endl;
+  }
 
  typedef  itk::RecursiveGaussianImageFilter <TImageType,TImageType> RGFType;
  typename RGFType::Pointer DGF0=RGFType::New();
@@ -215,11 +224,35 @@ typedef itk::ImageDuplicator< TImageType > DuplicatorType;
  DGF2->SetDirection(2);
 
   DGF0->SetInput(duplicator->GetOutput());
-  DGF0->Update();
+  try
+  {
+    DGF0->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+      std::cerr << "ExceptionObject caught !" << std::endl;
+      std::cerr << err << std::endl;
+  }
   DGF1->SetInput(DGF0->GetOutput());
-  DGF1->Update();
+  try
+  {
+    DGF1->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+      std::cerr << "ExceptionObject caught !" << std::endl;
+      std::cerr << err << std::endl;
+  }
   DGF2->SetInput(DGF1->GetOutput());
-  DGF2->Update();
+  try
+  {
+    DGF2->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+      std::cerr << "ExceptionObject caught !" << std::endl;
+      std::cerr << err << std::endl;
+  }
 
   return(DGF2->GetOutput());
 }
@@ -234,8 +267,16 @@ itk::SmartPointer<TImageType1> BoundarySmoothing(itk::SmartPointer<TImageType1> 
      scaler->SetOutputMinimum(0 );
      scaler->SetOutputMaximum( 1 );
      scaler->SetInput(Image);
-     scaler->Update();
 
+      try
+      {
+          scaler->Update();
+      }
+      catch (itk::ExceptionObject & err)
+      {
+          std::cerr << "ExceptionObject caught !" << std::endl;
+          std::cerr << err << std::endl;
+      }
      typedef typename itk::ImageRegionIterator <TImageType1> IteratorType;
 
     
@@ -274,65 +315,6 @@ itk::SmartPointer<TImageType1> BoundarySmoothing(itk::SmartPointer<TImageType1> 
     return(output);
    }
   else return(Image);
-/* typedef typename itk::Statistics::ScalarImageToHistogramGenerator<
-                                 TImageType1 > HistogramGeneratorType;
-
- typename  HistogramGeneratorType::Pointer histogramGenerator =
-                                        HistogramGeneratorType::New(); 
-
-  histogramGenerator->SetInput( Image );
-
-  histogramGenerator->SetNumberOfBins( 256 );
-  histogramGenerator->SetMarginalScale( 10.0 );
-
-  histogramGenerator->SetHistogramMin( -0.5 );
-  histogramGenerator->SetHistogramMax( 255.5 ); 
-
-  histogramGenerator->Compute();
-
- typedef typename HistogramGeneratorType::HistogramType HistogramType;
-
- const HistogramType * histogram = histogramGenerator->GetOutput();
- 
- 
- typedef typename itk::ImageRegionIterator <TImageType1> IteratorType;
-
-    
- typename TImageType1::IndexType IndexV;
-
- typename TImageType1::Pointer output = TImageType1::New();
- output->SetRegions(Image->GetBufferedRegion());
- output->SetOrigin(Image->GetOrigin());
- output->SetSpacing(Image->GetSpacing());
- output->SetDirection(Image->GetDirection());
- output->Allocate();
-
- IteratorType It = IteratorType( output, Image->GetBufferedRegion());
-  
- double min=10e10,a,m;
-
- for( It.GoToBegin(); !It.IsAtEnd(); ++It )
-    {
-      IndexV=It.GetIndex();	
-      a=Image->GetPixel(IndexV);
-      if (a>histogram->Quantile(0,0.6))
-        {
-         It.Set(a);
-         if (min>a) min=a;
-        }
-      else 
-        It.Set(0);	
-    }
-
-  for( It.GoToBegin(); !It.IsAtEnd(); ++It )
-    {
-      IndexV=It.GetIndex();
-      if (It.Get()==0)
-	It.Set(min);  
-    }
-  return(output);
-*/
-
 }
 
 
@@ -340,7 +322,10 @@ template<class TFixedImage,class TMovingImage, class TDeformationField>
 LocalCriteriaOptimizer<TFixedImage,TMovingImage,TDeformationField>
 ::LocalCriteriaOptimizer()
 {
-for (int i=0;i<FixedImageDimension;++i)   m_Sigma[i]=10;
+for (unsigned int i=0;i<FixedImageDimension;++i)
+{
+    m_Sigma[i]=10;
+}
 
 typename DefaultInterpolatorType::Pointer interp = DefaultInterpolatorType::New();
 m_MovingImageInterpolator = static_cast<InterpolatorType*>(interp.GetPointer() );
@@ -396,10 +381,11 @@ LocalCriteriaOptimizer<TFixedImage,TMovingImage,TDeformationField>
 IndexType indexV=it.GetIndex();
 
 
-for ( int i = 0; i < FixedImageDimension; ++i)
+for ( unsigned int i = 0; i < FixedImageDimension; ++i)
+{
     update[i]=1/(pow(m_SmoothedSimGrad->GetPixel(indexV).GetNorm(),2)+
     (m_SigmaI)/ (pow(m_SimilarityImage->GetPixel(indexV),2)) )*m_SmoothedSimGrad->GetPixel(indexV)[i];
-
+}
 
 if ( globalData )
  {
@@ -426,8 +412,6 @@ void
 LocalCriteriaOptimizer<TFixedImage,TMovingImage,TDeformationField>
 ::InitializeIteration(void)
 {
-
-
   if( !this->GetMovingImage() || !this->GetFixedImage()
       || !m_MovingImageInterpolator )
     {
@@ -458,7 +442,16 @@ LocalCriteriaOptimizer<TFixedImage,TMovingImage,TDeformationField>
   m_MovingImageWarper->SetEdgePaddingValue( 0 );
   m_MovingImageWarper->SetDisplacementField( this->GetDisplacementField() );
   m_MovingImageWarper->GetOutput()->SetRequestedRegion( this->GetDisplacementField()->GetRequestedRegion() );
-  m_MovingImageWarper->Update();
+
+  try
+  {
+      m_MovingImageWarper->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+      std::cerr << "ExceptionObject caught !" << std::endl;
+      std::cerr << err << std::endl;
+  }
  
   m_FixedImageWarper->SetOutputOrigin( this->m_FixedImageOrigin );
   m_FixedImageWarper->SetOutputSpacing( this->m_FixedImageSpacing );
@@ -467,7 +460,16 @@ LocalCriteriaOptimizer<TFixedImage,TMovingImage,TDeformationField>
   m_FixedImageWarper->SetEdgePaddingValue( 0 );
   m_FixedImageWarper->SetDisplacementField( this->GetInverseDeformationField() );
   m_FixedImageWarper->GetOutput()->SetRequestedRegion( this->GetInverseDeformationField()->GetRequestedRegion() );
-  m_FixedImageWarper->Update();
+
+  try
+  {
+      m_FixedImageWarper->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+      std::cerr << "ExceptionObject caught !" << std::endl;
+      std::cerr << err << std::endl;
+  }
 
   if (m_UseMask==true)
    {
@@ -480,7 +482,16 @@ LocalCriteriaOptimizer<TFixedImage,TMovingImage,TDeformationField>
       m_MaskImageWarper->SetEdgePaddingValue( 0 );
       m_MaskImageWarper->SetDisplacementField( this->GetDisplacementField() );
       m_MaskImageWarper->GetOutput()->SetRequestedRegion( this->GetDisplacementField()->GetRequestedRegion() );
-      m_MaskImageWarper->Update();
+
+      try
+      {
+          m_MaskImageWarper->Update();
+      }
+      catch (itk::ExceptionObject & err)
+      {
+          std::cerr << "ExceptionObject caught !" << std::endl;
+          std::cerr << err << std::endl;
+      }
 
    }
 
@@ -539,15 +550,30 @@ LocalCriteriaOptimizer<TFixedImage,TMovingImage,TDeformationField>
 typedef  itk::GradientImageFilter<MovingImageType> GradientMType;
 typename GradientMType::Pointer GradientM = GradientMType::New();
 GradientM->SetInput(MovImage);
-GradientM->Update();
+
+  try
+  {
+      GradientM->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+      std::cerr << "ExceptionObject caught !" << std::endl;
+      std::cerr << err << std::endl;
+  }
 
 typedef  itk::GradientImageFilter<FixedImageType> GradientFType;
 typename GradientFType::Pointer GradientF = GradientFType::New();
 GradientF->SetInput(FixImage);
-GradientF->Update();
 
-
-
+  try
+  {
+      GradientF->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+      std::cerr << "ExceptionObject caught !" << std::endl;
+      std::cerr << err << std::endl;
+  }
 
   typedef typename itk::ImageRegionIterator <VectorImageType> VectIteratorType;
 
@@ -579,7 +605,7 @@ GradientF->Update();
       IndexV=ItF.GetIndex();	
       IndexV1=ItM.GetIndex();
        
-      for (int i=0;i<FixedImageDimension;++i)
+      for (unsigned int i=0;i<FixedImageDimension;++i)
         {
          vector[i]=GradientF->GetOutput()->GetPixel(IndexV)[i];
          vector1[i]=GradientM->GetOutput()->GetPixel(IndexV1)[i];
@@ -649,13 +675,6 @@ LocalCriteriaOptimizer<TFixedImage,TMovingImage,TDeformationField>
 
   delete globalData;
 } 
-
-
-
-
-
-
-
 
 }//end namespace itk
 #endif

--- a/src/LCClogDemons/itkMultiResolutionLCCDeformableRegistration.txx
+++ b/src/LCClogDemons/itkMultiResolutionLCCDeformableRegistration.txx
@@ -84,13 +84,8 @@ MultiResolutionLCCDeformableRegistration<TFixedImage,TMovingImage,TField,TRealTy
 ::SetMovingImage(
   const MovingImageType * ptr )
 {
-#if (ITK_VERSION_MAJOR < 4)
-  this->ProcessObject::SetNthInput( 2, const_cast< MovingImageType * >( ptr ) );
-#else
   this->ProcessObject::SetNthInput( 2, const_cast<MovingImageType *>( ptr ) );
-#endif
 }
-
 
 // Get the moving image image.
 template <class TFixedImage, class TMovingImage, class TField, class TRealType>
@@ -99,12 +94,7 @@ const typename MultiResolutionLCCDeformableRegistration<TFixedImage,TMovingImage
 MultiResolutionLCCDeformableRegistration<TFixedImage,TMovingImage,TField,TRealType>
 ::GetMovingImage(void) const
 {
-  return dynamic_cast< const MovingImageType * >
-#if (ITK_VERSION_MAJOR < 4)
-  ( this->ProcessObject::GetInput( 2 ) );
-#else
-  ( this->ProcessObject::GetInput( 2 ) );
-#endif
+    return dynamic_cast< const MovingImageType * >(this->ProcessObject::GetInput(2));
 }
 
 // Set the mask image.
@@ -140,7 +130,6 @@ MultiResolutionLCCDeformableRegistration<TFixedImage,TMovingImage,TField,TRealTy
 
 
 //Set Boundary Checking
-
 template <class TFixedImage, class TMovingImage, class TField, class TRealType>
 void
 MultiResolutionLCCDeformableRegistration<TFixedImage,TMovingImage,TField,TRealType>
@@ -158,13 +147,8 @@ MultiResolutionLCCDeformableRegistration<TFixedImage,TMovingImage,TField,TRealTy
 ::SetFixedImage(
   const FixedImageType * ptr )
 {
-#if (ITK_VERSION_MAJOR < 4)
-  this->ProcessObject::SetNthInput( 1, const_cast< FixedImageType * >( ptr ) );
-#else
-  this->ProcessObject::SetNthInput( 1, const_cast<FixedImageType *>( ptr ) );
-#endif
+    this->ProcessObject::SetNthInput( 1, const_cast<FixedImageType *>( ptr ) );
 }
-
 
 // Get the fixed image.
 template <class TFixedImage, class TMovingImage, class TField, class TRealType>
@@ -173,14 +157,8 @@ const typename MultiResolutionLCCDeformableRegistration<TFixedImage,TMovingImage
 MultiResolutionLCCDeformableRegistration<TFixedImage,TMovingImage,TField,TRealType>
 ::GetFixedImage(void) const
 {
-  return dynamic_cast< const FixedImageType * >
-#if (ITK_VERSION_MAJOR < 4)
-    ( this->ProcessObject::GetInput( 1 ) );
-#else
-    ( this->ProcessObject::GetInput( 1 ) );
-#endif
+  return dynamic_cast< const FixedImageType * >(this->ProcessObject::GetInput(1));
 }
-
 
 template <class TFixedImage, class TMovingImage, class TField, class TRealType>
 std::vector<SmartPointer<DataObject> >::size_type
@@ -281,8 +259,10 @@ MultiResolutionLCCDeformableRegistration<TFixedImage,TMovingImage,TField,TRealTy
 ::SetStandardDeviationsWorldUnit( double value )
 {
     double tmp[ImageDimension];
-    for( int i=0; i<ImageDimension; i++ )
+    for( unsigned int i=0; i<ImageDimension; i++ )
+    {
         tmp[i] = value;
+    }
     SetStandardDeviationsWorldUnit( tmp );
 }
 
@@ -325,8 +305,10 @@ MultiResolutionLCCDeformableRegistration<TFixedImage,TMovingImage,TField,TRealTy
 ::SetStandardDeviationsVoxelUnit( double value )
 {
     double tmp[ImageDimension];
-    for( int i=0; i<ImageDimension; i++ )
+    for( unsigned int i=0; i<ImageDimension; i++ )
+    {
         tmp[i] = value;
+    }
     SetStandardDeviationsVoxelUnit( tmp );
 }
 
@@ -369,8 +351,10 @@ MultiResolutionLCCDeformableRegistration<TFixedImage,TMovingImage,TField,TRealTy
 ::SetUpdateFieldStandardDeviationsWorldUnit( double value )
 {
     double tmp[ImageDimension];
-    for( int i=0; i<ImageDimension; i++ )
+    for( unsigned int i=0; i<ImageDimension; i++ )
+    {
         tmp[i] = value;
+    }
     SetUpdateFieldStandardDeviationsWorldUnit( tmp );
 }
 
@@ -413,8 +397,10 @@ MultiResolutionLCCDeformableRegistration<TFixedImage,TMovingImage,TField,TRealTy
 ::SetUpdateFieldStandardDeviationsVoxelUnit( double value )
 {
     double tmp[ImageDimension];
-    for( int i=0; i<ImageDimension; i++ )
+    for( unsigned int i=0; i<ImageDimension; i++ )
+    {
         tmp[i] = value;
+    }
     SetUpdateFieldStandardDeviationsVoxelUnit( tmp );
 }
 
@@ -456,8 +442,10 @@ MultiResolutionLCCDeformableRegistration<TFixedImage,TMovingImage,TField,TRealTy
 ::SetSimilarityCriteriaStandardDeviationsWorldUnit( double value )
 {
     double tmp[ImageDimension];
-    for( int i=0; i<ImageDimension; i++ )
+    for( unsigned int i=0; i<ImageDimension; i++ )
+    {
         tmp[i] = value;
+    }
     SetSimilarityCriteriaStandardDeviationsWorldUnit( tmp );
 }
 
@@ -498,8 +486,10 @@ MultiResolutionLCCDeformableRegistration<TFixedImage,TMovingImage,TField,TRealTy
 ::SetSimilarityCriteriaStandardDeviationsVoxelUnit( double value )
 {
     double tmp[ImageDimension];
-    for( int i=0; i<ImageDimension; i++ )
+    for( unsigned int i=0; i<ImageDimension; i++ )
+    {
         tmp[i] = value;
+    }
     SetSimilarityCriteriaStandardDeviationsVoxelUnit( tmp );
 }
 
@@ -677,17 +667,23 @@ MultiResolutionLCCDeformableRegistration<TFixedImage,TMovingImage,TField,TRealTy
             smoother->SetInput( tempField );
             smoother->SetSigma( sigma );
             smoother->SetDirection( dim );
-
-            smoother->Update();
+     
+            try
+            {
+                smoother->Update();
+            }
+            catch (itk::ExceptionObject & err)
+            {
+                std::cerr << "ExceptionObject caught !" << std::endl;
+                std::cerr << err << std::endl;
+            }
 
             tempField = smoother->GetOutput();
             tempField->DisconnectPipeline();
         }
 
-
         // Now resample
         m_FieldExpander->SetInput( tempField );
-	//std::cout<<"Fixed Level "<<fixedLevel<<std::endl;
         typename FloatImageType::Pointer fi = m_FixedImagePyramid->GetOutput( fixedLevel );
         m_FieldExpander->SetSize(             fi->GetLargestPossibleRegion().GetSize() );
         m_FieldExpander->SetOutputStartIndex( fi->GetLargestPossibleRegion().GetIndex() );
@@ -701,21 +697,33 @@ MultiResolutionLCCDeformableRegistration<TFixedImage,TMovingImage,TField,TRealTy
     }
 
     if (m_UseMask)
-      {
-       m_ImageExpander->SetInput( m_MaskImage );
-       m_ImageExpander->SetShrinkFactors(pow(2.0,(int)(m_MovingImagePyramid->GetNumberOfLevels()-movingLevel-1)));
-       m_ImageExpander->Update();
-       m_RegistrationFilter->UseMask(m_UseMask);
-       m_RegistrationFilter->SetMaskImage(m_ImageExpander->GetOutput() );
-      }
-    else m_RegistrationFilter->UseMask(m_UseMask);
+    {
+        m_ImageExpander->SetInput( m_MaskImage );
+        m_ImageExpander->SetShrinkFactors(pow(2.0,(int)(m_MovingImagePyramid->GetNumberOfLevels()-movingLevel-1)));
+    
+        try
+        {
+            m_ImageExpander->Update();
+        }
+        catch (itk::ExceptionObject & err)
+        {
+            std::cerr << "ExceptionObject caught !" << std::endl;
+            std::cerr << err << std::endl;
+        }
+        m_RegistrationFilter->UseMask(m_UseMask);
+        m_RegistrationFilter->SetMaskImage(m_ImageExpander->GetOutput() );
+    }
+    else
+    {
+        m_RegistrationFilter->UseMask(m_UseMask);
+    }
 
     bool lastShrinkFactorsAllOnes = false;
 
     m_RegistrationFilter->SetRegularizationType(this->m_RegularizationType);
 
     if (m_RegularizationType==0)
-      {
+    {
         // Mode for smoothing or not the velocity field
         if ( this->m_SmoothVelocityField )
            m_RegistrationFilter->SmoothVelocityFieldOn();
@@ -735,28 +743,24 @@ MultiResolutionLCCDeformableRegistration<TFixedImage,TMovingImage,TField,TRealTy
         // Sets the filter standard deviation for update field regularization (voxel unit only)
         if ( !m_StandardDeviationWorldUnit )
            m_RegistrationFilter->SetUpdateFieldStandardDeviationsVoxelUnit( m_UpdateFieldStandardDeviations );
-       }
-
+    }
     else if (m_RegularizationType==1)
-       {
+    {
         // Set penalization for the harmonic energy term
         m_RegistrationFilter->SetHarmonicWeight(this->m_HarmonicWeight);
 
         // Set penalization for the bending energy term
         m_RegistrationFilter->SetBendingWeight(this->m_BendingWeight);
-       }
+    }
 
-        // Sets the filter standard deviation for the similarity criterion (voxel unit only)
+    // Sets the filter standard deviation for the similarity criterion (voxel unit only)
     m_RegistrationFilter->SetSimilarityCriteriaStandardDeviationsVoxelUnit( m_SimilarityCriteriaStandardDeviations );
-
-
     m_RegistrationFilter->SetSigmaI( this->m_SigmaI );
-
     m_RegistrationFilter->SetBoundaryCheck(this->m_BoundaryCheck);
+
     // Loop
     while ( !this->Halt() )
     {
-
         if( tempField.IsNull() )
         {
             m_RegistrationFilter->SetInitialVelocityField( NULL );
@@ -772,26 +776,16 @@ MultiResolutionLCCDeformableRegistration<TFixedImage,TMovingImage,TField,TRealTy
             m_FieldExpander->SetOutputOrigin(     fi->GetOrigin() );
             m_FieldExpander->SetOutputSpacing(    fi->GetSpacing());
             m_FieldExpander->SetOutputDirection(  fi->GetDirection());
-
             m_FieldExpander->UpdateLargestPossibleRegion();
             tempField = m_FieldExpander->GetOutput();
             tempField->DisconnectPipeline();
 
-	    
             m_RegistrationFilter->SetInitialVelocityField( tempField );
 
             // Resample the mask image to be the same size as the fixed image at the current level
             if (m_UseMask)
-
             {
               m_ImageExpander->SetInput( m_MaskImage );
-
-    /*        m_ImageExpander->SetSize(             fi->GetLargestPossibleRegion().GetSize() );
-              m_ImageExpander->SetOutputStartIndex( fi->GetLargestPossibleRegion().GetIndex() );
-              m_ImageExpander->SetOutputOrigin(     fi->GetOrigin() );
-              m_ImageExpander->SetOutputSpacing(    fi->GetSpacing());
-              m_ImageExpander->SetOutputDirection(  fi->GetDirection());
-*/
               m_ImageExpander->SetShrinkFactors(pow(2.0,(int)(m_MovingImagePyramid->GetNumberOfLevels()-movingLevel-1)));
               m_ImageExpander->UpdateLargestPossibleRegion();
            
@@ -803,51 +797,51 @@ MultiResolutionLCCDeformableRegistration<TFixedImage,TMovingImage,TField,TRealTy
 
         }
 
-
         // Setup registration filter and pyramids
         m_RegistrationFilter->SetMovingImage(        m_MovingImagePyramid->GetOutput(movingLevel) );
         m_RegistrationFilter->SetFixedImage(         m_FixedImagePyramid->GetOutput(fixedLevel) );
         m_RegistrationFilter->SetNumberOfIterations( m_NumberOfIterations[m_CurrentLevel] );
 
-
         // Resolution
         double resolution = 1;
-        for (int i=0; i<ImageDimension; i++)
+        for (unsigned int i=0; i<ImageDimension; i++)
         {
             double s1  = fixedImage->GetLargestPossibleRegion().GetSize()[i];
             double s2  = m_FixedImagePyramid->GetOutput(movingLevel)->GetLargestPossibleRegion().GetSize()[i];
             resolution = std::max( resolution, s1/s2 );
         }
 
-
         // Sets the filter standard deviation for global field regularization (world unit only)
         if ( m_StandardDeviationWorldUnit )
         {
             double sd[ImageDimension];
-            for (int i=0; i<ImageDimension; i++)
-              sd[i] = m_StandardDeviations[i];
+            for (unsigned int i=0; i<ImageDimension; i++)
+            {
+                sd[i] = m_StandardDeviations[i];
+            }
 
             m_RegistrationFilter->SetStandardDeviationsWorldUnit( sd );
         }
-
 
         // Sets the filter standard deviation for update field regularization (world unit only)
         if ( m_StandardDeviationWorldUnit )
         {
             double sd[ImageDimension];
-            for (int i=0; i<ImageDimension; i++)
+            for (unsigned int i=0; i<ImageDimension; i++)
+            {
               sd[i] = m_UpdateFieldStandardDeviations[i];
-
+            }
             m_RegistrationFilter->SetUpdateFieldStandardDeviationsWorldUnit( sd );
         }
 
-     // Sets the filter standard deviation for the similarity criterion (world unit only)
+        // Sets the filter standard deviation for the similarity criterion (world unit only)
         if ( m_StandardDeviationWorldUnit )
         {
             double sd[ImageDimension];
-            for (int i=0; i<ImageDimension; i++)
+            for (unsigned int i=0; i<ImageDimension; i++)
+            {
                 sd[i] = m_SimilarityCriteriaStandardDeviations[i] * resolution;
-
+            }
             m_RegistrationFilter->SetSimilarityCriteriaStandardDeviationsWorldUnit( sd );
         }
 
@@ -864,18 +858,13 @@ MultiResolutionLCCDeformableRegistration<TFixedImage,TMovingImage,TField,TRealTy
 
         // compute new velocity field
         m_RegistrationFilter->UpdateLargestPossibleRegion();
-       // std::cout<<"Smoothing velocity!"<<std::endl;
-       // m_RegistrationFilter->SmoothVelocityField();
 
         //Workaround for keep multithreading while regularing in Fourier domain
         tempField = m_RegistrationFilter->GetOutput();
-
         tempField->DisconnectPipeline();
 
-	
-	
-        // Increment level counter.
-        m_CurrentLevel++;
+        // // Increment level counter.
+         m_CurrentLevel++;
         movingLevel = std::min( (int) m_CurrentLevel,
                                     (int) m_MovingImagePyramid->GetNumberOfLevels() );
         fixedLevel = std::min( (int) m_CurrentLevel,
@@ -889,6 +878,7 @@ MultiResolutionLCCDeformableRegistration<TFixedImage,TMovingImage,TField,TRealTy
         {
             m_MovingImagePyramid->GetOutput( movingLevel - 1 )->ReleaseData();
         }
+
         if( fixedLevel > 0 )
         {
             m_FixedImagePyramid->GetOutput( fixedLevel - 1 )->ReleaseData();
@@ -948,7 +938,6 @@ MultiResolutionLCCDeformableRegistration<TFixedImage,TMovingImage,TField,TRealTy
     m_FieldExpander->GetOutput()->ReleaseData();
     m_RegistrationFilter->SetInput( NULL );
     m_RegistrationFilter->GetOutput()->ReleaseData();
-
 }
 
 
@@ -966,26 +955,18 @@ bool
 MultiResolutionLCCDeformableRegistration<TFixedImage,TMovingImage,TField,TRealType>
 ::Halt()
 {
-  // Halt the registration after the user-specified number of levels
-  if (m_NumberOfLevels != 0)
+    // Halt the registration after the user-specified number of levels
+    if (m_NumberOfLevels != 0)
     {
-    this->UpdateProgress( static_cast<float>( m_CurrentLevel ) /
-                          static_cast<float>( m_NumberOfLevels ) );
+        this->UpdateProgress( static_cast<float>( m_CurrentLevel ) /
+                              static_cast<float>( m_NumberOfLevels ) );
     }
 
-  if ( m_CurrentLevel >= m_NumberOfLevels )
+    if ( (m_CurrentLevel >= m_NumberOfLevels) || m_StopRegistrationFlag )
     {
-    return true;
+        return true;
     }
-  if ( m_StopRegistrationFlag )
-    {
-    return true;
-    }
-  else
-    { 
     return false; 
-    }
-
 }
 
 
@@ -997,11 +978,7 @@ MultiResolutionLCCDeformableRegistration<TFixedImage,TMovingImage,TField,TRealTy
 
   typename DataObject::Pointer output;
 
-#if (ITK_VERSION_MAJOR < 4)
   if( this->GetInput(0) )
-#else
-  if( this->GetInput(0) )
-#endif
     {
     // Initial velocity field is set.
     // Copy information from initial field.
@@ -1032,7 +1009,6 @@ void
 MultiResolutionLCCDeformableRegistration<TFixedImage,TMovingImage,TField,TRealType>
 ::GenerateInputRequestedRegion()
 {
-
   // call the superclass's implementation
   Superclass::GenerateInputRequestedRegion();
 
@@ -1065,7 +1041,6 @@ MultiResolutionLCCDeformableRegistration<TFixedImage,TMovingImage,TField,TRealTy
     {
     fixedPtr->SetRequestedRegion( outputPtr->GetRequestedRegion() );
     }
-
 }
 
 
@@ -1096,10 +1071,18 @@ typename MultiResolutionLCCDeformableRegistration<TFixedImage,TMovingImage,TFiel
 MultiResolutionLCCDeformableRegistration<TFixedImage,TMovingImage,TField,TRealType>
 ::GetDeformationField()
 {
-  //std::cout<<"MultiResolutionLCCDeformableRegistration::GetDeformationField"<<std::endl;
   m_Exponentiator->SetInput( this->GetVelocityField() );
   m_Exponentiator->ComputeInverseOff();
-  m_Exponentiator->Update();
+  
+  try
+  {
+    m_Exponentiator->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+    std::cerr << "ExceptionObject caught !" << std::endl;
+    std::cerr << err << std::endl;
+  }
   DeformationFieldPointer field = m_Exponentiator->GetOutput();
   field->DisconnectPipeline();
   return field;
@@ -1112,10 +1095,18 @@ typename MultiResolutionLCCDeformableRegistration<TFixedImage,TMovingImage,TFiel
 MultiResolutionLCCDeformableRegistration<TFixedImage,TMovingImage,TField,TRealType>
 ::GetInverseDeformationField()
 {
-  //std::cout<<"MultiResolutionLCCDeformableRegistration::GetInverseDeformationField"<<std::endl;
   m_Exponentiator->SetInput( this->GetVelocityField() );
   m_Exponentiator->ComputeInverseOn();
-  m_Exponentiator->Update();
+  
+  try
+  {
+      m_Exponentiator->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+      std::cerr << "ExceptionObject caught !" << std::endl;
+      std::cerr << err << std::endl;
+  }
   DeformationFieldPointer field = m_Exponentiator->GetOutput();
   field->DisconnectPipeline();
   // Reset compute inverse back to off to avoid some broder effects

--- a/src/LogDemons/itkDisplacementFieldCompositionFilter.hxx
+++ b/src/LogDemons/itkDisplacementFieldCompositionFilter.hxx
@@ -90,7 +90,15 @@ DisplacementFieldCompositionFilter<TInputImage, TOutputImage>
   progress->RegisterInternalFilter(m_Adder, 0.4);
 
   // Update the pipeline
-  m_Adder->Update();
+  try
+  {
+      m_Adder->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+      std::cerr << "ExceptionObject caught !" << std::endl;
+      std::cerr << err << std::endl;
+  }    
 
   // Region passing stuff
   this->GraftOutput( m_Adder->GetOutput() );

--- a/src/LogDemons/itkDisplacementToVelocityFieldLogFilter.hxx
+++ b/src/LogDemons/itkDisplacementToVelocityFieldLogFilter.hxx
@@ -70,7 +70,15 @@ DisplacementToVelocityFieldLogFilter<TInputImage, TOutputImage>
     m_ExpComp->SetVelocityField(current);
     m_ExpComp->SetInput( this->GetInput() );
 
-    m_ExpComp->Update();
+    try
+    {
+        m_ExpComp->Update();
+    }
+    catch (itk::ExceptionObject & err)
+    {
+        std::cerr << "ExceptionObject caught !" << std::endl;
+        std::cerr << err << std::endl;
+    }
 
     typename InputImageType::Pointer leftField  = m_ExpComp->GetOutput();
     typename InputImageType::Pointer rightField = current;
@@ -97,8 +105,16 @@ DisplacementToVelocityFieldLogFilter<TInputImage, TOutputImage>
 
     m_BCHCalculator->GetOutput()->SetRequestedRegion( this->GetOutput()->GetRequestedRegion() );
 
-    m_BCHCalculator->Update();
-
+    try
+    {
+        m_BCHCalculator->Update();
+    }
+    catch (itk::ExceptionObject & err)
+    {
+        std::cerr << "ExceptionObject caught !" << std::endl;
+        std::cerr << err << std::endl;
+    }
+    
     current = m_BCHCalculator->GetOutput();
     current->DisconnectPipeline();
 

--- a/src/LogDemons/itkExponentialDeformationFieldImageFilter2.txx
+++ b/src/LogDemons/itkExponentialDeformationFieldImageFilter2.txx
@@ -69,7 +69,16 @@ ExponentialDeformationFieldImageFilter<TInputImage,TOutputImage>
 
   m_Multiplier->SetInput(this->GetInput());
   m_Multiplier->SetConstant(m_MultiplicativeFactor);
-  m_Multiplier->Update();
+
+  try
+  {
+      m_Multiplier->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+      std::cerr << "ExceptionObject caught !" << std::endl;
+      std::cerr << err << std::endl;
+  }
 
   InputImageConstPointer inputPtr = m_Multiplier->GetOutput();
 
@@ -128,33 +137,52 @@ ExponentialDeformationFieldImageFilter<TInputImage,TOutputImage>
     numiter = m_MaximumNumberOfIterations;
     }
 
-
   ProgressReporter progress(this, 0, numiter+1, numiter+1);
 
   if( numiter == 0 )
-    {
+  {
     if ( !this->m_ComputeInverse )
-      {
-      m_Caster->SetInput(inputPtr);
-      m_Caster->GraftOutput(this->GetOutput());
-      m_Caster->Update();
-      // Region passing stuff
-      this->GraftOutput( m_Caster->GetOutput() );
-      }
+    {
+        m_Caster->SetInput(inputPtr);
+        m_Caster->GraftOutput(this->GetOutput());
+
+        try
+        {
+            m_Caster->Update();
+        }
+        catch (itk::ExceptionObject & err)
+        {
+            std::cerr << "ExceptionObject caught !" << std::endl;
+            std::cerr << err << std::endl;
+        }
+
+        // Region passing stuff
+        this->GraftOutput( m_Caster->GetOutput() );
+    }
     else
-      {
-      m_Oppositer->SetInput(inputPtr);
-      m_Oppositer->GraftOutput(this->GetOutput());
-      m_Oppositer->Update();
-      // Region passing stuff
-      this->GraftOutput( m_Oppositer->GetOutput() );
-      }
+    {
+        m_Oppositer->SetInput(inputPtr);
+        m_Oppositer->GraftOutput(this->GetOutput());
+
+        try
+        {
+            m_Oppositer->Update();
+        }
+        catch (itk::ExceptionObject & err)
+        {
+            std::cerr << "ExceptionObject caught !" << std::endl;
+            std::cerr << err << std::endl;
+        }
+
+        // Region passing stuff
+        this->GraftOutput( m_Oppositer->GetOutput() );
+
+    }
 
     this->GetOutput()->Modified();
-
     progress.CompletedPixel();
     return;
-    }
+  }
 
   // Get the first order approximation (division by 2^numiter)
   m_Divider->SetInput(inputPtr);
@@ -168,20 +196,25 @@ ExponentialDeformationFieldImageFilter<TInputImage,TOutputImage>
        m_Divider->SetConstant( -static_cast<InputPixelRealValueType>(1<<numiter) );
     }
 
-  m_Divider->Update();
-
+  try
+  {
+      m_Divider->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+      std::cerr << "ExceptionObject caught !" << std::endl;
+      std::cerr << err << std::endl;
+  }
   // Region passing stuff
   this->GraftOutput( m_Divider->GetOutput() );
   this->GetOutput()->Modified();
 
   progress.CompletedPixel();
 
-
   // Do the iterative composition of the vector field
   m_Warper->SetOutputOrigin(inputPtr->GetOrigin());
   m_Warper->SetOutputSpacing(inputPtr->GetSpacing());
   m_Warper->SetOutputDirection(inputPtr->GetDirection());
-
 
   for( unsigned int i=0; i<numiter; i++ )
     {
@@ -191,7 +224,15 @@ ExponentialDeformationFieldImageFilter<TInputImage,TOutputImage>
     m_Warper->GetOutput()->SetRequestedRegion(
        this->GetOutput()->GetRequestedRegion() );
 
-    m_Warper->Update();
+    try
+    {
+        m_Warper->Update();
+    }
+    catch (itk::ExceptionObject & err)
+    {
+        std::cerr << "ExceptionObject caught !" << std::endl;
+        std::cerr << err << std::endl;
+    }
 
     OutputImagePointer warpedIm = m_Warper->GetOutput();
     warpedIm->DisconnectPipeline();
@@ -203,7 +244,15 @@ ExponentialDeformationFieldImageFilter<TInputImage,TOutputImage>
     m_Adder->GetOutput()->SetRequestedRegion(
       this->GetOutput()->GetRequestedRegion() );
 
-    m_Adder->Update();
+    try
+    {
+        m_Adder->Update();
+    }
+    catch (itk::ExceptionObject & err)
+    {
+        std::cerr << "ExceptionObject caught !" << std::endl;
+        std::cerr << err << std::endl;
+    }
 
     // Region passing stuff
     this->GraftOutput( m_Adder->GetOutput() );

--- a/src/LogDemons/itkLogDomainDeformableRegistrationFilter.hxx
+++ b/src/LogDemons/itkLogDomainDeformableRegistrationFilter.hxx
@@ -64,11 +64,7 @@ void
 LogDomainDeformableRegistrationFilter<TFixedImage, TMovingImage, TField>
 ::SetInitialVelocityField( VelocityFieldType * ptr )
 {
-#if (ITK_VERSION_MAJOR < 4)
-  this->SetNthInput( VELOCITYFIELD_IMAGE_CODE, ptr );
-#else
-  this->SetNthInput( VELOCITYFIELD_IMAGE_CODE, ptr );
-#endif
+    this->SetNthInput( VELOCITYFIELD_IMAGE_CODE, ptr );
 }
 
 // Set the fixed image.
@@ -78,11 +74,7 @@ LogDomainDeformableRegistrationFilter<TFixedImage, TMovingImage, TField>
 ::SetFixedImage(
   const FixedImageType * ptr )
 {
-#if (ITK_VERSION_MAJOR < 4)
   this->ProcessObject::SetNthInput( FIXED_IMAGE_CODE, const_cast<FixedImageType *>( ptr ) );
-#else
-  this->ProcessObject::SetNthInput( FIXED_IMAGE_CODE, const_cast<FixedImageType *>( ptr ) );
-#endif
 }
 
 // Get the fixed image.
@@ -91,14 +83,9 @@ const typename LogDomainDeformableRegistrationFilter<TFixedImage, TMovingImage, 
 ::FixedImageType *
 LogDomainDeformableRegistrationFilter<TFixedImage, TMovingImage, TField>
 ::GetFixedImage() const
-  {
-  return dynamic_cast<const FixedImageType *>
-#if (ITK_VERSION_MAJOR < 4)
-         ( this->ProcessObject::GetInput( FIXED_IMAGE_CODE ) );
-#else
-         ( this->ProcessObject::GetInput( FIXED_IMAGE_CODE ) );
-#endif
-  }
+{
+    return dynamic_cast<const FixedImageType *>(this->ProcessObject::GetInput( FIXED_IMAGE_CODE ));
+}
 
 template <class TFixedImage, class TMovingImage, class TField>
 /*const HACK:  This should be const */
@@ -118,11 +105,7 @@ LogDomainDeformableRegistrationFilter<TFixedImage, TMovingImage, TField>
 ::SetMovingImage(
   const MovingImageType * ptr )
 {
-#if (ITK_VERSION_MAJOR < 4)
-  this->ProcessObject::SetNthInput( MOVING_IMAGE_CODE, const_cast<MovingImageType *>( ptr ) );
-#else
-  this->ProcessObject::SetNthInput( MOVING_IMAGE_CODE, const_cast<MovingImageType *>( ptr ) );
-#endif
+    this->ProcessObject::SetNthInput(MOVING_IMAGE_CODE, const_cast<MovingImageType *>( ptr ));
 }
 
 // Get the moving image.
@@ -131,14 +114,9 @@ const typename LogDomainDeformableRegistrationFilter<TFixedImage, TMovingImage, 
 ::MovingImageType
 * LogDomainDeformableRegistrationFilter<TFixedImage, TMovingImage, TField>
 ::GetMovingImage() const
-  {
-  return dynamic_cast<const MovingImageType *>
-#if (ITK_VERSION_MAJOR < 4)
-         ( this->ProcessObject::GetInput( MOVING_IMAGE_CODE ) );
-#else
-         ( this->ProcessObject::GetInput( MOVING_IMAGE_CODE ) );
-#endif
-  }
+{
+    return dynamic_cast<const MovingImageType *>(this->ProcessObject::GetInput( MOVING_IMAGE_CODE ));
+}
 
 template <class TFixedImage, class TMovingImage, class TField>
 std::vector<SmartPointer<DataObject> >::size_type
@@ -212,7 +190,6 @@ LogDomainDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 ::SetStandardDeviations(
   double value )
 {
-
     std::cout<< "WARNING : Deprecated function" << std::endl;
 
     unsigned int j;
@@ -241,8 +218,10 @@ LogDomainDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 ::SetStandardDeviationsWorldUnit( double value )
 {
     double tmp[ImageDimension];
-    for( int i=0; i<ImageDimension; i++ )
+    for( unsigned int i=0; i<ImageDimension; i++ )
+    {
         tmp[i] = value;
+    }
     SetStandardDeviationsWorldUnit( tmp );
 }
 
@@ -285,8 +264,10 @@ LogDomainDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 ::SetStandardDeviationsVoxelUnit( double value )
 {
     double tmp[ImageDimension];
-    for( int i=0; i<ImageDimension; i++ )
+    for( unsigned int i=0; i<ImageDimension; i++ )
+    {
         tmp[i] = value;
+    }
     SetStandardDeviationsVoxelUnit( tmp );
 }
 
@@ -329,7 +310,6 @@ LogDomainDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 ::SetUpdateFieldStandardDeviations(
   double value )
 {
-
     std::cout<< "WARNING : Deprecated function" << std::endl;
 
   unsigned int j;
@@ -359,8 +339,10 @@ LogDomainDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 ::SetUpdateFieldStandardDeviationsWorldUnit( double value )
 {
     double tmp[ImageDimension];
-    for( int i=0; i<ImageDimension; i++ )
-        tmp[i] = value;
+    for( unsigned int i=0; i<ImageDimension; i++ )
+    {
+      tmp[i] = value;
+    }
     SetUpdateFieldStandardDeviationsWorldUnit( tmp );
 }
 
@@ -403,8 +385,10 @@ LogDomainDeformableRegistrationFilter<TFixedImage,TMovingImage,TField>
 ::SetUpdateFieldStandardDeviationsVoxelUnit( double value )
 {
     double tmp[ImageDimension];
-    for( int i=0; i<ImageDimension; i++ )
-        tmp[i] = value;
+    for( unsigned int i=0; i<ImageDimension; i++ )
+    {
+      tmp[i] = value;
+    }
     SetUpdateFieldStandardDeviationsVoxelUnit( tmp );
 }
 
@@ -482,7 +466,6 @@ void
 LogDomainDeformableRegistrationFilter<TFixedImage, TMovingImage, TField>
 ::InitializeIteration()
 {
-  // std::cout<<"LogDomainDeformableRegistrationFilter::InitializeIteration"<<std::endl;
   MovingImageConstPointer movingPtr = this->GetMovingImage();
   FixedImageConstPointer  fixedPtr = this->GetFixedImage();
 
@@ -517,34 +500,29 @@ void
 LogDomainDeformableRegistrationFilter<TFixedImage, TMovingImage, TField>
 ::CopyInputToOutput()
 {
+    typename Superclass::InputImageType::ConstPointer  inputPtr  = this->GetInput(VELOCITYFIELD_IMAGE_CODE);
 
-#if (ITK_VERSION_MAJOR < 4)
-  typename Superclass::InputImageType::ConstPointer  inputPtr  = this->GetInput(VELOCITYFIELD_IMAGE_CODE);
-#else
-  typename Superclass::InputImageType::ConstPointer  inputPtr  = this->GetInput(VELOCITYFIELD_IMAGE_CODE);
-#endif
-
-  if( inputPtr )
+    if( inputPtr )
     {
-    this->Superclass::CopyInputToOutput();
+        this->Superclass::CopyInputToOutput();
     }
-  else
+    else
     {
-    typename Superclass::PixelType zeros;
-    for( unsigned int j = 0; j < ImageDimension; j++ )
-      {
-      zeros[j] = 0;
-      }
+        typename Superclass::PixelType zeros;
+        for( unsigned int j = 0; j < ImageDimension; j++ )
+        {
+          zeros[j] = 0;
+        }
 
-    typename OutputImageType::Pointer output = this->GetVelocityField();
+        typename OutputImageType::Pointer output = this->GetVelocityField();
 
-    ImageRegionIterator<OutputImageType> out(output, output->GetRequestedRegion() );
+        ImageRegionIterator<OutputImageType> out(output, output->GetRequestedRegion() );
 
-    while( !out.IsAtEnd() )
-      {
-      out.Value() =  zeros;
-      ++out;
-      }
+        while( !out.IsAtEnd() )
+        {
+          out.Value() =  zeros;
+          ++out;
+        }
     }
 }
 
@@ -553,36 +531,28 @@ void
 LogDomainDeformableRegistrationFilter<TFixedImage, TMovingImage, TField>
 ::GenerateOutputInformation()
 {
-  // std::cout<<"LogDomainDeformableRegistrationFilter::GenerateOutputInformation"<<std::endl;
   typename DataObject::Pointer output;
 
-#if (ITK_VERSION_MAJOR < 4)
   if( this->GetInput(VELOCITYFIELD_IMAGE_CODE) )
-#else
-  if( this->GetInput(VELOCITYFIELD_IMAGE_CODE) )
-#endif
-    {
+  {
     // Initial velocity field is set.
     // Copy information from initial field.
     this->Superclass::GenerateOutputInformation();
 
-    }
+  }
   else if( this->GetFixedImage() )
-    {
+  {
     // Initial deforamtion field is not set.
     // Copy information from the fixed image.
-    for( unsigned int idx = 0; idx <
-         this->GetNumberOfOutputs(); ++idx )
-      {
+    for( unsigned int idx = 0; idx < this->GetNumberOfOutputs(); ++idx )
+    {
       output = this->GetOutput(idx);
       if( output )
-        {
+      {
         output->CopyInformation(this->GetFixedImage() );
-        }
       }
-
     }
-
+  }
 }
 
 template <class TFixedImage, class TMovingImage, class TField>
@@ -590,7 +560,6 @@ void
 LogDomainDeformableRegistrationFilter<TFixedImage, TMovingImage, TField>
 ::GenerateInputRequestedRegion()
 {
-  // std::cout<<"LogDomainDeformableRegistrationFilter::GenerateInputRequestedRegion"<<std::endl;
   // call the superclass's implementation
   Superclass::GenerateInputRequestedRegion();
 
@@ -604,13 +573,7 @@ LogDomainDeformableRegistrationFilter<TFixedImage, TMovingImage, TField>
 
   // just propagate up the output requested region for
   // the fixed image and initial velocity field.
-#if (ITK_VERSION_MAJOR < 4)
-  VelocityFieldPointer inputPtr =
-    const_cast<VelocityFieldType *>( this->GetInput(VELOCITYFIELD_IMAGE_CODE) );
-#else
-  VelocityFieldPointer inputPtr =
-    const_cast<VelocityFieldType *>( this->GetInput(VELOCITYFIELD_IMAGE_CODE) );
-#endif
+  VelocityFieldPointer inputPtr = const_cast<VelocityFieldType *>( this->GetInput(VELOCITYFIELD_IMAGE_CODE) );
   VelocityFieldPointer outputPtr = this->GetVelocityField();
   FixedImagePointer    fixedPtr = const_cast<FixedImageType *>( this->GetFixedImage() );
 
@@ -641,7 +604,6 @@ void
 LogDomainDeformableRegistrationFilter<TFixedImage, TMovingImage, TField>
 ::Initialize()
 {
-  // std::cout<<"LogDomainDeformableRegistrationFilter::Initialize"<<std::endl;
   this->Superclass::Initialize();
   m_StopRegistrationFlag = false;
 }
@@ -652,35 +614,14 @@ void
 LogDomainDeformableRegistrationFilter<TFixedImage, TMovingImage, TField>
 ::SmoothVelocityField()
 {
-    if (m_RegularizationType == 1)
-      {
-
-
-        float param[2];
-         param[0]=m_HarmonicWeight;
-         param[1]=m_BendingWeight;
-
-       /*  typedef typename itk::VectorRegularizationFilter<VelocityFieldType> RegularizerType;
-         //std::cout<<param[0]<<" "<<param[1]<<std::endl;
-
-         typename RegularizerType::Pointer Regularizer=RegularizerType::New();
-         Regularizer->SetInput(this->GetOutput());
-         Regularizer->SetFactor(param);
-
-         Regularizer->Update();
-
-         this->GraftOutput(Regularizer->GetOutput());
-      */
+    if (m_RegularizationType == 0)
+    {
+        if (this->GetSmoothVelocityField())
+        {
+            // The output buffer will be overwritten with new data.
+            this->SmoothGivenField(this->GetVelocityField(), this->m_StandardDeviations);
         }
-
-    else if (m_RegularizationType == 0)
-      {
-       if (this->GetSmoothVelocityField())
-          {
-           // The output buffer will be overwritten with new data.
-           this->SmoothGivenField(this->GetVelocityField(), this->m_StandardDeviations);
-          }
-      }
+    }
 }
 
 // Smooth update field using a separable Gaussian kernel
@@ -756,7 +697,16 @@ LogDomainDeformableRegistrationFilter<TFixedImage, TMovingImage, TField>
     // todo: make sure we only smooth within the buffered region
     smoother->SetOperator( *oper );
     smoother->SetInput( field );
-    smoother->Update();
+
+    try
+    {
+        smoother->Update();
+    }
+    catch (itk::ExceptionObject & err)
+    {
+        std::cerr << "ExceptionObject caught !" << std::endl;
+        std::cerr << err << std::endl;
+    }
 
     if( j < ImageDimension - 1 )
       {
@@ -789,11 +739,19 @@ typename LogDomainDeformableRegistrationFilter<TFixedImage, TMovingImage, TField
 LogDomainDeformableRegistrationFilter<TFixedImage, TMovingImage, TField>
 ::GetDeformationField()
 {
-  // std::cout<<"LogDomainDeformableRegistration::GetDeformationField"<<std::endl;
-  m_Exponentiator->SetInput( this->GetVelocityField() );
-  m_Exponentiator->GetOutput()->SetRequestedRegion( this->GetVelocityField()->GetRequestedRegion() );
-  m_Exponentiator->Update();
-  return m_Exponentiator->GetOutput();
+    m_Exponentiator->SetInput( this->GetVelocityField() );
+    m_Exponentiator->GetOutput()->SetRequestedRegion( this->GetVelocityField()->GetRequestedRegion() );
+    
+    try
+    {
+        m_Exponentiator->Update();
+    }
+    catch (itk::ExceptionObject & err)
+    {
+        std::cerr << "ExceptionObject caught !" << std::endl;
+        std::cerr << err << std::endl;
+    }
+    return m_Exponentiator->GetOutput();
 }
 
 template <class TFixedImage, class TMovingImage, class TField>
@@ -802,10 +760,18 @@ typename LogDomainDeformableRegistrationFilter<TFixedImage, TMovingImage, TField
 LogDomainDeformableRegistrationFilter<TFixedImage, TMovingImage, TField>
 ::GetInverseDisplacementField()
 {
-  // std::cout<<"LogDomainDeformableRegistration::GetInverseDisplacementField"<<std::endl;
   m_InverseExponentiator->SetInput( this->GetVelocityField() );
   m_InverseExponentiator->GetOutput()->SetRequestedRegion( this->GetVelocityField()->GetRequestedRegion() );
-  m_InverseExponentiator->Update();
+
+  try
+  {
+      m_InverseExponentiator->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+      std::cerr << "ExceptionObject caught !" << std::endl;
+      std::cerr << err << std::endl;
+  }
   return m_InverseExponentiator->GetOutput();
 }
 

--- a/src/LogDemons/itkLogDomainDemonsRegistrationFilter.hxx
+++ b/src/LogDemons/itkLogDomainDemonsRegistrationFilter.hxx
@@ -63,7 +63,6 @@ void
 LogDomainDemonsRegistrationFilter<TFixedImage, TMovingImage, TField>
 ::InitializeIteration()
 {
-  // std::cout<<"LogDomainDemonsRegistrationFilter::InitializeIteration"<<std::endl;
   // update variables in the equation object
   DemonsRegistrationFunctionType * const f = this->DownCastDifferenceFunctionType();
 
@@ -184,7 +183,6 @@ LogDomainDemonsRegistrationFilter<TFixedImage, TMovingImage, TField>
 ::ApplyUpdate(const TimeStepType& dt)
 #endif
 {
-  // std::cout<<"LogDomainDemonsRegistrationFilter::ApplyUpdate"<<std::endl;
   // If we smooth the update buffer before applying it, then the are
   // approximating a viscuous problem as opposed to an elastic problem
   if( this->GetSmoothUpdateField() )
@@ -201,7 +199,16 @@ LogDomainDemonsRegistrationFilter<TFixedImage, TMovingImage, TField>
     m_Multiplier->SetInput( this->GetUpdateBuffer() );
     m_Multiplier->GraftOutput( this->GetUpdateBuffer() );
     // in place update
-    m_Multiplier->Update();
+
+    try
+    {
+        m_Multiplier->Update();
+    }
+    catch (itk::ExceptionObject & err)
+    {
+        std::cerr << "ExceptionObject caught !" << std::endl;
+        std::cerr << err << std::endl;
+    }
     // graft output back to this->GetUpdateBuffer()
     this->GetUpdateBuffer()->Graft( m_Multiplier->GetOutput() );
     }
@@ -221,7 +228,15 @@ LogDomainDemonsRegistrationFilter<TFixedImage, TMovingImage, TField>
   m_BCHFilter->GetOutput()->SetRequestedRegion( this->GetVelocityField()->GetRequestedRegion() );
 
   // Triggers in place update
-  m_BCHFilter->Update();
+  try
+  {
+      m_BCHFilter->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+      std::cerr << "ExceptionObject caught !" << std::endl;
+      std::cerr << err << std::endl;
+  }
 
   // Region passing stuff
   this->GraftOutput( m_BCHFilter->GetOutput() );

--- a/src/LogDemons/itkMultiResolutionLogDomainDeformableRegistration.hxx
+++ b/src/LogDemons/itkMultiResolutionLogDomainDeformableRegistration.hxx
@@ -92,11 +92,7 @@ MultiResolutionLogDomainDeformableRegistration<TFixedImage, TMovingImage, TField
 ::SetMovingImage(
   const MovingImageType * ptr )
 {
-#if (ITK_VERSION_MAJOR < 4)
   this->ProcessObject::SetNthInput( MOVING_IMAGE_CODE, const_cast<MovingImageType *>( ptr ) );
-#else
-  this->ProcessObject::SetNthInput( MOVING_IMAGE_CODE, const_cast<MovingImageType *>( ptr ) );
-#endif
 }
 
 // Get the moving image image.
@@ -105,14 +101,9 @@ const typename MultiResolutionLogDomainDeformableRegistration<TFixedImage, TMovi
 ::MovingImageType
 * MultiResolutionLogDomainDeformableRegistration<TFixedImage, TMovingImage, TField, TRealType>
 ::GetMovingImage(void) const
-  {
-  return dynamic_cast<const MovingImageType *>
-#if (ITK_VERSION_MAJOR < 4)
-         ( this->ProcessObject::GetInput( MOVING_IMAGE_CODE ) );
-#else
-         ( this->ProcessObject::GetInput( MOVING_IMAGE_CODE ) );
-#endif
-  }
+{
+    return dynamic_cast<const MovingImageType *>(this->ProcessObject::GetInput( MOVING_IMAGE_CODE ));
+}
 
 // Set the fixed image.
 template <class TFixedImage, class TMovingImage, class TField, class TRealType>
@@ -121,11 +112,7 @@ MultiResolutionLogDomainDeformableRegistration<TFixedImage, TMovingImage, TField
 ::SetFixedImage(
   const FixedImageType * ptr )
 {
-#if (ITK_VERSION_MAJOR < 4)
-  this->ProcessObject::SetNthInput( FIXED_IMAGE_CODE, const_cast<FixedImageType *>( ptr ) );
-#else
-  this->ProcessObject::SetNthInput( FIXED_IMAGE_CODE, const_cast<FixedImageType *>( ptr ) );
-#endif
+    this->ProcessObject::SetNthInput( FIXED_IMAGE_CODE, const_cast<FixedImageType *>( ptr ) );
 }
 
 // Get the fixed image.
@@ -134,14 +121,9 @@ const typename MultiResolutionLogDomainDeformableRegistration<TFixedImage, TMovi
 ::FixedImageType
 * MultiResolutionLogDomainDeformableRegistration<TFixedImage, TMovingImage, TField, TRealType>
 ::GetFixedImage(void) const
-  {
-  return dynamic_cast<const FixedImageType *>
-#if (ITK_VERSION_MAJOR < 4)
-         ( this->ProcessObject::GetInput( FIXED_IMAGE_CODE ) );
-#else
-         ( this->ProcessObject::GetInput( FIXED_IMAGE_CODE ) );
-#endif
-  }
+{
+    return dynamic_cast<const FixedImageType *>(this->ProcessObject::GetInput( FIXED_IMAGE_CODE ));
+}
 
 template <class TFixedImage, class TMovingImage, class TField, class TRealType>
 std::vector<SmartPointer<DataObject> >::size_type
@@ -239,8 +221,10 @@ MultiResolutionLogDomainDeformableRegistration<TFixedImage,TMovingImage,TField,T
 ::SetStandardDeviationsWorldUnit( double value )
 {
     double tmp[ImageDimension];
-    for( int i=0; i<ImageDimension; i++ )
+    for( unsigned int i=0; i<ImageDimension; i++ )
+    {
         tmp[i] = value;
+    }
     SetStandardDeviationsWorldUnit( tmp );
 }
 
@@ -283,8 +267,10 @@ MultiResolutionLogDomainDeformableRegistration<TFixedImage,TMovingImage,TField,T
 ::SetStandardDeviationsVoxelUnit( double value )
 {
     double tmp[ImageDimension];
-    for( int i=0; i<ImageDimension; i++ )
+    for( unsigned int i=0; i<ImageDimension; i++ )
+    {
         tmp[i] = value;
+    }
     SetStandardDeviationsVoxelUnit( tmp );
 }
 
@@ -327,8 +313,10 @@ MultiResolutionLogDomainDeformableRegistration<TFixedImage,TMovingImage,TField,T
 ::SetUpdateFieldStandardDeviationsWorldUnit( double value )
 {
     double tmp[ImageDimension];
-    for( int i=0; i<ImageDimension; i++ )
+    for( unsigned int i=0; i<ImageDimension; i++ )
+    {
         tmp[i] = value;
+    }
     SetUpdateFieldStandardDeviationsWorldUnit( tmp );
 }
 
@@ -371,8 +359,10 @@ MultiResolutionLogDomainDeformableRegistration<TFixedImage,TMovingImage,TField,T
 ::SetUpdateFieldStandardDeviationsVoxelUnit( double value )
 {
     double tmp[ImageDimension];
-    for( int i=0; i<ImageDimension; i++ )
+    for( unsigned int i=0; i<ImageDimension; i++ )
+    {
         tmp[i] = value;
+    }
     SetUpdateFieldStandardDeviationsVoxelUnit( tmp );
 }
 
@@ -482,17 +472,13 @@ MultiResolutionLogDomainDeformableRegistration<TFixedImage, TMovingImage, TField
     itkExceptionMacro( << "Registration filter not set" );
     }
 
-#if (ITK_VERSION_MAJOR < 4)
   if( this->m_InitialVelocityField && this->GetInput(VELOCITYFIELD_IMAGE_CODE) )
-#else
-  if( this->m_InitialVelocityField && this->GetInput(VELOCITYFIELD_IMAGE_CODE) )
-#endif
-    {
+  {
     itkExceptionMacro( << "Only one initial velocity can be given. "
                        << "SetInitialVelocityField should not be used in "
-                       << "cunjunction with SetArbitraryInitialVelocityField "
+                       << "conjunction with SetArbitraryInitialVelocityField "
                        << "or SetInput.");
-    }
+  }
 
   // Create the image pyramids.
   m_MovingImagePyramid->SetInput( movingImage );
@@ -512,13 +498,8 @@ MultiResolutionLogDomainDeformableRegistration<TFixedImage, TMovingImage, TField
                                           (int) m_FixedImagePyramid->GetNumberOfLevels() );
 
   VelocityFieldPointer tempField = nullptr;
+  VelocityFieldPointer inputPtr = const_cast<VelocityFieldType *>( this->GetInput(VELOCITYFIELD_IMAGE_CODE) );
 
-  VelocityFieldPointer inputPtr =
-#if (ITK_VERSION_MAJOR < 4)
-    const_cast<VelocityFieldType *>( this->GetInput(VELOCITYFIELD_IMAGE_CODE) );
-#else
-    const_cast<VelocityFieldType *>( this->GetInput(VELOCITYFIELD_IMAGE_CODE) );
-#endif
   if( this->m_InitialVelocityField )
     {
     tempField = this->m_InitialVelocityField;
@@ -549,7 +530,15 @@ MultiResolutionLogDomainDeformableRegistration<TFixedImage, TMovingImage, TField
       smoother->SetSigma( sigma );
       smoother->SetDirection( dim );
 
-      smoother->Update();
+      try
+      {
+          smoother->Update();
+      }
+      catch (itk::ExceptionObject & err)
+      {
+          std::cerr << "ExceptionObject caught !" << std::endl;
+          std::cerr << err << std::endl;
+      }
 
       tempField = smoother->GetOutput();
       tempField->DisconnectPipeline();
@@ -653,7 +642,7 @@ else if (m_RegularizationType==1)
 
     // Resolution
     double resolution = 1;
-    for (int i=0; i<ImageDimension; i++)
+    for (unsigned int i=0; i<ImageDimension; i++)
     {
         double s1  = fixedImage->GetLargestPossibleRegion().GetSize()[i];
         double s2  = m_FixedImagePyramid->GetOutput(movingLevel)->GetLargestPossibleRegion().GetSize()[i];
@@ -665,19 +654,20 @@ else if (m_RegularizationType==1)
     if ( m_StandardDeviationWorldUnit )
     {
         double sd[ImageDimension];
-        for (int i=0; i<ImageDimension; i++)
+        for (unsigned int i=0; i<ImageDimension; i++)
+        {
             sd[i] = m_StandardDeviations[i] * resolution;
+        }
         m_RegistrationFilter->SetStandardDeviationsWorldUnit( sd );
 
     // Sets the filter standard deviation for update field regularization (world unit only)
 
-        for (int i=0; i<ImageDimension; i++)
+        for (unsigned int i=0; i<ImageDimension; i++)
+        {
             sd[i] = m_UpdateFieldStandardDeviations[i] * resolution;
+        }
         m_RegistrationFilter->SetUpdateFieldStandardDeviationsWorldUnit( sd );
     }
-
-
-
 
     // cache shrink factors for computing the next expand factors.
     lastShrinkFactorsAllOnes = true;
@@ -768,24 +758,20 @@ MultiResolutionLogDomainDeformableRegistration<TFixedImage, TMovingImage, TField
 {
   // Halt the registration after the user-specified number of levels
   if( m_NumberOfLevels != 0 )
-    {
+  {
     this->UpdateProgress( static_cast<float>( m_CurrentLevel )
                           / static_cast<float>( m_NumberOfLevels ) );
-    }
+  }
 
   if( m_CurrentLevel >= m_NumberOfLevels )
-    {
+  {
     return true;
-    }
+  }
   if( m_StopRegistrationFlag )
-    {
+  {
     return true;
-    }
-  else
-    {
-    return false;
-    }
-
+  }
+  return false;
 }
 
 template <class TFixedImage, class TMovingImage, class TField, class TRealType>
@@ -796,33 +782,25 @@ MultiResolutionLogDomainDeformableRegistration<TFixedImage, TMovingImage, TField
 
   typename DataObject::Pointer output;
 
-#if (ITK_VERSION_MAJOR < 4)
   if( this->GetInput(VELOCITYFIELD_IMAGE_CODE) )
-#else
-  if( this->GetInput(VELOCITYFIELD_IMAGE_CODE) )
-#endif
-    {
-    // Initial velocity field is set.
-    // Copy information from initial field.
-    this->Superclass::GenerateOutputInformation();
-
-    }
+  {
+      // Initial velocity field is set.
+      // Copy information from initial field.
+      this->Superclass::GenerateOutputInformation();
+  }
   else if( this->GetFixedImage() )
-    {
+  {
     // Initial deforamtion field is not set.
     // Copy information from the fixed image.
-    for( unsigned int idx = 0; idx <
-         this->GetNumberOfOutputs(); ++idx )
-      {
+    for( unsigned int idx = 0; idx < this->GetNumberOfOutputs(); ++idx )
+    {
       output = this->GetOutput(idx);
       if( output )
-        {
+      {
         output->CopyInformation(this->GetFixedImage() );
-        }
       }
-
     }
-
+  }
 }
 
 template <class TFixedImage, class TMovingImage, class TField, class TRealType>
@@ -830,40 +808,31 @@ void
 MultiResolutionLogDomainDeformableRegistration<TFixedImage, TMovingImage, TField, TRealType>
 ::GenerateInputRequestedRegion()
 {
-
   // call the superclass's implementation
   Superclass::GenerateInputRequestedRegion();
 
   // request the largest possible region for the moving image
-  MovingImagePointer movingPtr =
-    const_cast<MovingImageType *>( this->GetMovingImage() );
+  MovingImagePointer movingPtr = const_cast<MovingImageType *>( this->GetMovingImage() );
   if( movingPtr )
-    {
+  {
     movingPtr->SetRequestedRegionToLargestPossibleRegion();
-    }
+  }
 
   // just propagate up the output requested region for
   // the fixed image and initial velocity field.
-  VelocityFieldPointer inputPtr =
-#if (ITK_VERSION_MAJOR < 4)
-    const_cast<VelocityFieldType *>( this->GetInput(VELOCITYFIELD_IMAGE_CODE) );
-#else
-    const_cast<VelocityFieldType *>( this->GetInput(VELOCITYFIELD_IMAGE_CODE) );
-#endif
+  VelocityFieldPointer inputPtr  = const_cast<VelocityFieldType *>(this->GetInput(VELOCITYFIELD_IMAGE_CODE));
   VelocityFieldPointer outputPtr = this->GetOutput();
-  FixedImagePointer    fixedPtr =
-    const_cast<FixedImageType *>( this->GetFixedImage() );
+  FixedImagePointer    fixedPtr  = const_cast<FixedImageType *>( this->GetFixedImage() );
 
   if( inputPtr )
-    {
+  {
     inputPtr->SetRequestedRegion( outputPtr->GetRequestedRegion() );
-    }
+  }
 
   if( fixedPtr )
-    {
+  {
     fixedPtr->SetRequestedRegion( outputPtr->GetRequestedRegion() );
-    }
-
+  }
 }
 
 template <class TFixedImage, class TMovingImage, class TField, class TRealType>
@@ -892,10 +861,18 @@ typename MultiResolutionLogDomainDeformableRegistration<TFixedImage, TMovingImag
 MultiResolutionLogDomainDeformableRegistration<TFixedImage, TMovingImage, TField, TRealType>
 ::GetDeformationField()
 {
-  // std::cout<<"MultiResolutionLogDomainDeformableRegistration::GetDeformationField"<<std::endl;
   m_Exponentiator->SetInput( this->GetVelocityField() );
   m_Exponentiator->ComputeInverseOff();
-  m_Exponentiator->Update();
+
+  try
+  {
+      m_Exponentiator->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+      std::cerr << "ExceptionObject caught !" << std::endl;
+      std::cerr << err << std::endl;
+  }
   DeformationFieldPointer field = m_Exponentiator->GetOutput();
   field->DisconnectPipeline();
   return field;
@@ -907,10 +884,18 @@ typename MultiResolutionLogDomainDeformableRegistration<TFixedImage, TMovingImag
 MultiResolutionLogDomainDeformableRegistration<TFixedImage, TMovingImage, TField, TRealType>
 ::GetInverseDisplacementField()
 {
-  // std::cout<<"MultiResolutionLogDomainDeformableRegistration::GetInverseDisplacementField"<<std::endl;
   m_Exponentiator->SetInput( this->GetVelocityField() );
   m_Exponentiator->ComputeInverseOn();
-  m_Exponentiator->Update();
+
+  try
+  {
+      m_Exponentiator->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+      std::cerr << "ExceptionObject caught !" << std::endl;
+      std::cerr << err << std::endl;
+  }
   DeformationFieldPointer field = m_Exponentiator->GetOutput();
   field->DisconnectPipeline();
   // Reset compute inverse back to off to avoid some broder effects

--- a/src/LogDemons/itkSymmetricLogDomainDemonsRegistrationFilter.hxx
+++ b/src/LogDemons/itkSymmetricLogDomainDemonsRegistrationFilter.hxx
@@ -143,7 +143,6 @@ void
 SymmetricLogDomainDemonsRegistrationFilter<TFixedImage, TMovingImage, TField>
 ::Initialize()
 {
-  // std::cout<<"SymmetricLogDomainDemonsRegistrationFilter::Initialize"<<std::endl;
   this->Superclass::Initialize();
 
   const FixedImageType *  fixim = this->GetFixedImage();
@@ -330,13 +329,8 @@ SymmetricLogDomainDemonsRegistrationFilter<TFixedImage, TMovingImage, TField>::T
 SymmetricLogDomainDemonsRegistrationFilter<TFixedImage, TMovingImage, TField>
 ::ThreadedCalculateChange(const ThreadRegionType & regionToProcess, ThreadIdType)
 {
-  typedef typename VelocityFieldType::RegionType     RegionType;
   typedef typename VelocityFieldType::SizeType       SizeType;
-  typedef typename VelocityFieldType::SizeValueType  SizeValueType;
-  typedef typename VelocityFieldType::IndexType      IndexType;
-  typedef typename VelocityFieldType::IndexValueType IndexValueType;
-  typedef typename
-  FiniteDifferenceFunctionType::NeighborhoodType    NeighborhoodIteratorType;
+  typedef typename FiniteDifferenceFunctionType::NeighborhoodType    NeighborhoodIteratorType;
   typedef ImageRegionIterator<VelocityFieldType> UpdateIteratorType;
 
   VelocityFieldPointer output = this->GetVelocityField();
@@ -479,7 +473,15 @@ SymmetricLogDomainDemonsRegistrationFilter<TFixedImage, TMovingImage, TField>
       m_Multiplier->SetInput( this->GetUpdateBuffer() );
       m_Multiplier->GraftOutput( this->GetUpdateBuffer() );
       // in place update
-      m_Multiplier->Update();
+      try
+      {
+          m_Multiplier->Update();
+      }
+      catch (itk::ExceptionObject & err)
+      {
+          std::cerr << "ExceptionObject caught !" << std::endl;
+          std::cerr << err << std::endl;
+      }
       // graft output back to this->GetUpdateBuffer()
       this->GetUpdateBuffer()->Graft( m_Multiplier->GetOutput() );
       }
@@ -491,7 +493,15 @@ SymmetricLogDomainDemonsRegistrationFilter<TFixedImage, TMovingImage, TField>
     m_Adder->GetOutput()->SetRequestedRegion( this->GetVelocityField()->GetRequestedRegion() );
 
     // Triggers in place update
-    m_Adder->Update();
+    try
+    {
+        m_Adder->Update();
+    }
+    catch (itk::ExceptionObject & err)
+    {
+        std::cerr << "ExceptionObject caught !" << std::endl;
+        std::cerr << err << std::endl;
+    }
 
     // Region passing stuff
     this->GraftOutput( m_Adder->GetOutput() );
@@ -516,14 +526,30 @@ SymmetricLogDomainDemonsRegistrationFilter<TFixedImage, TMovingImage, TField>
       m_Multiplier->SetInput( this->GetUpdateBuffer() );
       m_Multiplier->GraftOutput( this->GetUpdateBuffer() );
       // in place update
-      m_Multiplier->Update();
+      try
+      {
+          m_Multiplier->Update();
+      }
+      catch (itk::ExceptionObject & err)
+      {
+          std::cerr << "ExceptionObject caught !" << std::endl;
+          std::cerr << err << std::endl;
+      }
       // graft output back to this->GetUpdateBuffer()
       this->GetUpdateBuffer()->Graft( m_Multiplier->GetOutput() );
 
       m_Multiplier->SetInput( this->GetBackwardUpdateBuffer() );
       m_Multiplier->GraftOutput( this->GetBackwardUpdateBuffer() );
       // in place update
-      m_Multiplier->Update();
+      try
+      {
+          m_Multiplier->Update();
+      }
+      catch (itk::ExceptionObject & err)
+      {
+          std::cerr << "ExceptionObject caught !" << std::endl;
+          std::cerr << err << std::endl;
+      }
       // graft output back to this->GetUpdateBuffer()
       this->GetBackwardUpdateBuffer()->Graft( m_Multiplier->GetOutput() );
       }
@@ -541,7 +567,16 @@ SymmetricLogDomainDemonsRegistrationFilter<TFixedImage, TMovingImage, TField>
     bchfilter->SetInput( 1, this->GetUpdateBuffer() );
 
     bchfilter->GetOutput()->SetRequestedRegion( this->GetVelocityField()->GetRequestedRegion() );
-    bchfilter->Update();
+
+    try
+    {
+        bchfilter->Update();
+    }
+    catch (itk::ExceptionObject & err)
+    {
+        std::cerr << "ExceptionObject caught !" << std::endl;
+        std::cerr << err << std::endl;
+    }
     VelocityFieldPointer Zf = bchfilter->GetOutput();
     Zf->DisconnectPipeline();
 
@@ -557,7 +592,16 @@ SymmetricLogDomainDemonsRegistrationFilter<TFixedImage, TMovingImage, TField>
     bchfilter->SetInput( 1, this->GetBackwardUpdateBuffer() );
 
     bchfilter->GetOutput()->SetRequestedRegion( this->GetVelocityField()->GetRequestedRegion() );
-    bchfilter->Update();
+
+    try
+    {
+        bchfilter->Update();
+    }
+    catch (itk::ExceptionObject & err)
+    {
+        std::cerr << "ExceptionObject caught !" << std::endl;
+        std::cerr << err << std::endl;
+    }
     VelocityFieldPointer Zb = bchfilter->GetOutput();
     Zb->DisconnectPipeline();
 
@@ -577,7 +621,16 @@ SymmetricLogDomainDemonsRegistrationFilter<TFixedImage, TMovingImage, TField>
 
     // Triggers in place update
     m_Multiplier->GetOutput()->SetRequestedRegion( this->GetVelocityField()->GetRequestedRegion() );
-    m_Multiplier->Update();
+
+    try
+    {
+        m_Multiplier->Update();
+    }
+    catch (itk::ExceptionObject & err)
+    {
+        std::cerr << "ExceptionObject caught !" << std::endl;
+        std::cerr << err << std::endl;
+    }
 
     // Region passing stuff
     this->GraftOutput( m_Multiplier->GetOutput() );

--- a/src/LogDemons/itkVectorRegularizationFilter.txx
+++ b/src/LogDemons/itkVectorRegularizationFilter.txx
@@ -57,23 +57,53 @@ void VectorRegularizationFilter<TRealVectorImage>
     {
      m_RealExtractor->SetInput(this->GetInput());
      m_RealExtractor->SetIndex(i);
-     m_RealExtractor->Update();
+
+      try
+      {
+          m_RealExtractor->Update();
+      }
+      catch (itk::ExceptionObject & err)
+      {
+          std::cerr << "ExceptionObject caught !" << std::endl;
+          std::cerr << err << std::endl;
+      }
      m_FFTFilter->SetInput(m_RealExtractor->GetOutput());
 
-     if (this->GetOutput()->GetLargestPossibleRegion().GetSize()[0]%2==1)
+      try
       {
-    //   m_FFTInvFilter->SetActualXDimensionIsOdd(true);
+          m_FFTFilter->Update();
       }
-     m_FFTFilter->Update();
-     m_ShiftFilter->SetInput(m_FFTFilter->GetOutput());
-     m_ShiftFilter->SetInverse(false);
-     m_ShiftFilter->Update();
-     m_ComplexImageArray[i]=m_ShiftFilter->GetOutput();
-     m_ComplexImageArray[i]->DisconnectPipeline();
-     m_ComplexComposer->SetInput(i,m_ComplexImageArray[i]);
+      catch (itk::ExceptionObject & err)
+      {
+          std::cerr << "ExceptionObject caught !" << std::endl;
+          std::cerr << err << std::endl;
+      }
+      m_ShiftFilter->SetInput(m_FFTFilter->GetOutput());
+      m_ShiftFilter->SetInverse(false);
+
+      try
+      {
+          m_ShiftFilter->Update();
+      }
+      catch (itk::ExceptionObject & err)
+      {
+          std::cerr << "ExceptionObject caught !" << std::endl;
+          std::cerr << err << std::endl;
+      }
+      m_ComplexImageArray[i]=m_ShiftFilter->GetOutput();
+      m_ComplexImageArray[i]->DisconnectPipeline();
+      m_ComplexComposer->SetInput(i,m_ComplexImageArray[i]);
     }
 
-  m_ComplexComposer->Update();
+  try
+  {
+      m_ComplexComposer->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+      std::cerr << "ExceptionObject caught !" << std::endl;
+      std::cerr << err << std::endl;
+  }
   m_ComplexSolution=m_ComplexComposer->GetOutput();  
  
   for (int i=0;i<ImageDimension;++i)
@@ -106,24 +136,53 @@ void VectorRegularizationFilter<TRealVectorImage>
     {
      m_ComplexExtractor->SetInput(m_ComplexSolution);
      m_ComplexExtractor->SetIndex(i);
-     m_ComplexExtractor->Update();
-     m_ShiftFilter->SetInput(m_ComplexExtractor->GetOutput());
-     m_ShiftFilter->SetInverse(true);
-     m_ShiftFilter->Update();
-     m_FFTInvFilter->SetInput(m_ShiftFilter->GetOutput());
 
-     if (!m_ShiftFilter->GetOutput()->GetLargestPossibleRegion().GetSize()[0]%2)
+      try
       {
-      // m_FFTInvFilter->SetActualXDimensionIsOdd(true);
+          m_ComplexExtractor->Update();
       }
+      catch (itk::ExceptionObject & err)
+      {
+          std::cerr << "ExceptionObject caught !" << std::endl;
+          std::cerr << err << std::endl;
+      }
+      m_ShiftFilter->SetInput(m_ComplexExtractor->GetOutput());
+      m_ShiftFilter->SetInverse(true);
 
-     m_FFTInvFilter->Update();
+      try
+      {
+          m_ShiftFilter->Update();
+      }
+      catch (itk::ExceptionObject & err)
+      {
+          std::cerr << "ExceptionObject caught !" << std::endl;
+          std::cerr << err << std::endl;
+      }
+      m_FFTInvFilter->SetInput(m_ShiftFilter->GetOutput());
+
+      try
+      {
+          m_FFTInvFilter->Update();
+      }
+      catch (itk::ExceptionObject & err)
+      {
+          std::cerr << "ExceptionObject caught !" << std::endl;
+          std::cerr << err << std::endl;
+      }
      m_RealImageArray[i]=m_FFTInvFilter->GetOutput();
      m_RealImageArray[i]->DisconnectPipeline();
      m_RealComposer->SetInput(i,m_RealImageArray[i]);
     }   
 
- m_RealComposer->Update();
+  try
+  {
+      m_RealComposer->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+      std::cerr << "ExceptionObject caught !" << std::endl;
+      std::cerr << err << std::endl;
+  }
  this->GraftOutput(m_RealComposer->GetOutput());
 }
  

--- a/src/LogDemons/itkVelocityFieldBCHCompositionFilter.hxx
+++ b/src/LogDemons/itkVelocityFieldBCHCompositionFilter.hxx
@@ -152,7 +152,16 @@ VelocityFieldBCHCompositionFilter<TInputImage, TOutputImage>
     }
 
   m_Adder->GraftOutput( this->GetOutput() );
-  m_Adder->Update();
+
+  try
+  {
+      m_Adder->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+      std::cerr << "ExceptionObject caught !" << std::endl;
+      std::cerr << err << std::endl;
+  }
   this->GraftOutput( m_Adder->GetOutput() );
 }
 

--- a/src/SVFLogJacobian/SVFLogJacobian.cxx
+++ b/src/SVFLogJacobian/SVFLogJacobian.cxx
@@ -254,7 +254,16 @@ int main( int argc, char ** argv )
   DividerType::Pointer Divider=DividerType::New();
   Divider->SetInput(Out1);
   Divider->SetConstant(divider );
-  Divider->Update();
+
+  try
+  {
+      Divider->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+      std::cerr << "ExceptionObject caught !" << std::endl;
+      std::cerr << err << std::endl;
+  }
 
 
   /**
@@ -312,19 +321,45 @@ int main( int argc, char ** argv )
   derivative1->SetInput(componentExtractor1->GetOutput());
   derivative2->SetInput(componentExtractor2->GetOutput());
 
-  derivative0->Update();
-  derivative1->Update();
-  derivative2->Update();
+  try
+  {
+      derivative0->Update();
+      derivative1->Update();
+      derivative2->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+      std::cerr << "ExceptionObject caught !" << std::endl;
+      std::cerr << err << std::endl;
+  }
   
   AddImgFilterType::Pointer addFilter = AddImgFilterType::New();
   addFilter->SetInput1( derivative0->GetOutput() );
   addFilter->SetInput2( derivative1->GetOutput() );
-  addFilter->Update();
+
+  try
+  {
+      addFilter->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+      std::cerr << "ExceptionObject caught !" << std::endl;
+      std::cerr << err << std::endl;
+  }
 
   AddImgFilterType::Pointer addFilter1 = AddImgFilterType::New();
   addFilter1->SetInput1( derivative2->GetOutput() );
   addFilter1->SetInput2(addFilter->GetOutput());
-  addFilter1->Update();
+
+  try
+  {
+      addFilter1->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+      std::cerr << "ExceptionObject caught !" << std::endl;
+      std::cerr << err << std::endl;
+  }
 
   ImageType::Pointer Image=addFilter1->GetOutput();
 
@@ -348,7 +383,16 @@ typedef itk::WarpVectorImageFilter<VectorImageType,VectorImageType,VectorImageTy
 
 
   ExpImage->SetInput(Image);
-  ExpImage->Update();
+
+  try
+  {
+      ExpImage->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+      std::cerr << "ExceptionObject caught !" << std::endl;
+      std::cerr << err << std::endl;
+  }
 
   typedef itk::WarpImageFilter<ImageType,ImageType,VectorImageType> WarpImgType;
   WarpImgType::Pointer WarpImg=WarpImgType::New();
@@ -365,7 +409,7 @@ typedef itk::WarpVectorImageFilter<VectorImageType,VectorImageType,VectorImageTy
       /**
         * Iterative step Forward Euler: compute numiter times logJac(exp(vi))=logJac(exp(vi-1))|exp(v0)+logJac(exp(vi-1)) 
        **/
-      for( int i=0; i<numiter; i++ )
+      for( unsigned int i=0; i<numiter; i++ )
         {
          WarpImg->SetInput(Image);
          VectorWarper->SetInput(Vect1);
@@ -387,27 +431,53 @@ typedef itk::WarpVectorImageFilter<VectorImageType,VectorImageType,VectorImageTy
           Add->SetInput1(WarpImg->GetOutput());
  
 	  if (i==0)
-	    {
-	     Add->SetInput2(Image);
-	     VectorWarper->SetDisplacementField(Vect1);
-	    }
-          else
-	    {
-	     Add->SetInput2(Add->GetOutput());
-	     VectorWarper->SetDisplacementField(VectorAdder->GetOutput());
-            }
-	  
-	  Add->Update();
-          VectorWarper->GetOutput()->SetRequestedRegion(Vect1->GetRequestedRegion());
-          VectorWarper->Update();
-          WarpedIm = VectorWarper->GetOutput();
-          WarpedIm->DisconnectPipeline();
-           
-          VectorAdder->SetInput1(Vect1);
+	  {
+	      Add->SetInput2(Image);
+	      VectorWarper->SetDisplacementField(Vect1);
+	  }
+    else
+	  {
+	      Add->SetInput2(Add->GetOutput());
+	      VectorWarper->SetDisplacementField(VectorAdder->GetOutput());
+    }
+
+    try
+    {    
+        Add->Update();
+    }
+    catch (itk::ExceptionObject & err)
+    {
+        std::cerr << "ExceptionObject caught !" << std::endl;
+        std::cerr << err << std::endl;
+    }
+
+    VectorWarper->GetOutput()->SetRequestedRegion(Vect1->GetRequestedRegion());
+
+    try
+    {
+        VectorWarper->Update();
+    }
+    catch (itk::ExceptionObject & err)
+    {
+        std::cerr << "ExceptionObject caught !" << std::endl;
+        std::cerr << err << std::endl;
+    }
+    WarpedIm = VectorWarper->GetOutput();
+    WarpedIm->DisconnectPipeline();
+      
+    VectorAdder->SetInput1(Vect1);
 	  VectorAdder->SetInput2(WarpedIm);
 	  VectorAdder->GetOutput()->SetRequestedRegion(Vect1->GetRequestedRegion() );
-	  VectorAdder->Update(); 
 
+    try
+    {
+	      VectorAdder->Update();
+    }
+    catch (itk::ExceptionObject & err)
+    {
+        std::cerr << "ExceptionObject caught !" << std::endl;
+        std::cerr << err << std::endl;
+    }
 	}
       }
    else
@@ -415,39 +485,91 @@ typedef itk::WarpVectorImageFilter<VectorImageType,VectorImageType,VectorImageTy
   /**
     *     Iterative step Scaling and Squaring: compute numiter times logJac(exp(vi))=log[det(Jac(exp(vi-1)))|exp(vi-1)]+log[det(Jac(exp(vi-1)))] 
    **/
-      for( int i=0; i<numiter; i++ )
+      for( unsigned int i=0; i<numiter; i++ )
 	{
-         WarpImg->SetInput(ExpImage->GetOutput());
-         WarpImg->SetDisplacementField(Vect1);
-         WarpImg->Update();
+          WarpImg->SetInput(ExpImage->GetOutput());
+          WarpImg->SetDisplacementField(Vect1);
+          try
+          {
+              WarpImg->Update();
+          }
+          catch (itk::ExceptionObject & err)
+          {
+              std::cerr << "ExceptionObject caught !" << std::endl;
+              std::cerr << err << std::endl;
+          }
 
-         LogImage->SetInput(WarpImg->GetOutput());
-         LogImage->Update();
+          LogImage->SetInput(WarpImg->GetOutput());
 
-         Add->SetInput1(LogImage->GetOutput());
-         Add->SetInput2(Image);
-         Add->Update();
+          try
+          {
+              LogImage->Update();
+          }
+          catch (itk::ExceptionObject & err)
+          {
+              std::cerr << "ExceptionObject caught !" << std::endl;
+              std::cerr << err << std::endl;
+          }
 
-         VectorWarper->SetInput(Vect1); 
-         VectorWarper->SetDisplacementField(Vect1); 
-         VectorWarper->GetOutput()->SetRequestedRegion(Vect1->GetRequestedRegion());
-         VectorWarper->Update();
+          Add->SetInput1(LogImage->GetOutput());
+          Add->SetInput2(Image);
+
+          try
+          {
+              Add->Update();
+          }
+          catch (itk::ExceptionObject & err)
+          {
+              std::cerr << "ExceptionObject caught !" << std::endl;
+              std::cerr << err << std::endl;
+          }
+
+          VectorWarper->SetInput(Vect1); 
+          VectorWarper->SetDisplacementField(Vect1); 
+          VectorWarper->GetOutput()->SetRequestedRegion(Vect1->GetRequestedRegion());
+
+          try
+          {
+              VectorWarper->Update();
+          }
+          catch (itk::ExceptionObject & err)
+          {
+              std::cerr << "ExceptionObject caught !" << std::endl;
+              std::cerr << err << std::endl;
+          }
    
-         WarpedIm= VectorWarper->GetOutput(); 
-         WarpedIm->DisconnectPipeline();
+          WarpedIm= VectorWarper->GetOutput(); 
+          WarpedIm->DisconnectPipeline();
 
-         VectorAdder->SetInput1(Vect1);
-         VectorAdder->SetInput2(WarpedIm);
-         VectorAdder->GetOutput()->SetRequestedRegion(Vect1->GetRequestedRegion());
-         VectorAdder->Update();
-     
+          VectorAdder->SetInput1(Vect1);
+          VectorAdder->SetInput2(WarpedIm);
+          VectorAdder->GetOutput()->SetRequestedRegion(Vect1->GetRequestedRegion());
 
-         Vect1=VectorAdder->GetOutput();
-         Vect1->DisconnectPipeline();
-         Image=Add->GetOutput();
-         Image->DisconnectPipeline();
-         ExpImage->SetInput(Add->GetOutput());
-         ExpImage->Update();
+          try
+          {
+              VectorAdder->Update();
+          }
+          catch (itk::ExceptionObject & err)
+          {
+              std::cerr << "ExceptionObject caught !" << std::endl;
+              std::cerr << err << std::endl;
+          }
+
+          Vect1=VectorAdder->GetOutput();
+          Vect1->DisconnectPipeline();
+          Image=Add->GetOutput();
+          Image->DisconnectPipeline();
+          ExpImage->SetInput(Add->GetOutput());
+
+          try
+          {
+              ExpImage->Update();
+          }
+          catch (itk::ExceptionObject & err)
+          {
+              std::cerr << "ExceptionObject caught !" << std::endl;
+              std::cerr << err << std::endl;
+          }
         }
       }
 
@@ -456,7 +578,16 @@ typedef itk::WarpVectorImageFilter<VectorImageType,VectorImageType,VectorImageTy
 
   WriterImg->SetInput(Add->GetOutput());
   WriterImg->SetFileName(param.OutputImage);
-  WriterImg->Update();
+
+  try
+  {
+      WriterImg->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+      std::cerr << "ExceptionObject caught !" << std::endl;
+      std::cerr << err << std::endl;
+  }
 
 
   return EXIT_SUCCESS;

--- a/src/medInriaPlugin/LCCLogDemons.cpp
+++ b/src/medInriaPlugin/LCCLogDemons.cpp
@@ -203,7 +203,7 @@ int LCCLogDemonsPrivate::update()
         qDebug() << "ExceptionObject caught ! (startRegistration)" << err.what();
         return 1;
     }
-    
+
     time_t t2 = clock();
     
     qDebug() << "Elasped time: " << (double)(t2-t1)/(double)CLOCKS_PER_SEC;
@@ -243,7 +243,7 @@ int LCCLogDemonsPrivate::update()
                                    >::New());
         break;
     }
-    
+
     try {
         resampler->Update();
     }
@@ -251,7 +251,7 @@ int LCCLogDemonsPrivate::update()
         qDebug() << e.GetDescription();
         return 1;
     }
-    
+
     itk::ImageBase<3>::Pointer result = resampler->GetOutput();
     result->DisconnectPipeline();
     


### PR DESCRIPTION
I was working on https://github.com/medInria/medInria-public/issues/878 (my data crashes medInria using LCC Log Demons).

While trying to understand this repository, i did some cleaning which are important because the code is really old and difficult to read:
 * removal of some useless `#if (ITK_VERSION_MAJOR < 4)`
 * solve some warnings ("unsigned int" and unused variables)
 * removal of commented lines which make difficult the reading of the code
 * secure ITK `Update` with some `try/catch`
 * indent properly some methods which were unreadable

:m: